### PR TITLE
[5/5] Contracts with paramaters that have names that are rust keywords cause compile errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,10 @@ pub mod example {
         crate = crate
     );
     crate::contract!(
+        "examples/truffle/build/contracts/SimpleLibrary.json",
+        crate = crate
+    );
+    crate::contract!(
         "examples/truffle/build/contracts/LinkedContract.json",
         crate = crate
     );


### PR DESCRIPTION
This happens for example with solidity libraries where parameters are called `self`. Also adds sample library contract that exhibits this problem. We solve this by adding a `_` to the end of the identifier.