### PR TITLE
Rename `example` feature to `samples`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - cargo build --all-features --verbose --all
   - cargo test --all-features --verbose --all
   - cargo fmt --all -- --check
-  - cargo clippy --all
+  - cargo clippy --all --all-features --all-targets -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,4 @@ tiny-keccak = "1.5"
 web3 = "0.8"
 
 [dev-dependencies]
-anyhow = "1.0"
 rustversion = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "ethcontract"
 
 [features]
 default = []
-example = []
+samples = []
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ $ cargo +beta run --example async
 This example deploys a ERC20 token and interacts with the contract with various
 accounts.
 
-## Example documentation
+## Sample Contracts Documentation
 
-We added some examples of generated contracts from our sample contract collection
+We added some samples of generated contracts from our sample contract collection
 gated behind a feature. This feature is **only intended to be used for document
 generation**. In order to view the documentation for these contracts you need to
 first build the contracts and then generate documentation for the crate with the
-`example` feature enabled:
+`samples` feature enabled:
 
 ```sh
 $ (cd examples/truffle; npm run build)
-$ cargo doc --features example --open
+$ cargo doc --features samples --open
 ```
 
-This will open a browser at the documentation root. Look under the `example`
-module for the example contracts to get a feel for how the generated types look.
+This will open a browser at the documentation root. Look under the `samples`
+module for the sample contracts to get a feel for how the generated types look.

--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -60,7 +60,7 @@ mod tests {
             ("abfoocdefg", true, "abbarcdefg"),
             ("abfoocdfooefgfoo", true, "abbarcdfooefgfoo"),
         ] {
-            let mut value = value.to_string();
+            let mut value = (*value).to_string();
             assert_eq!(value.replace_once_in_place("foo", "bar"), *matched);
             assert_eq!(&value, expected);
         }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,3 +1,5 @@
+ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
+
 #[rustversion::since(1.39)]
 fn main() {
     use ethcontract::transaction::Account;
@@ -6,8 +8,6 @@ fn main() {
     use web3::api::Web3;
     use web3::transports::Http;
     use web3::types::{Address, TransactionRequest, H256};
-
-    ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
 
     async fn print_balance_of(instance: &RustCoin, account: Address) {
         let balance = instance

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,5 +1,3 @@
-ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
-
 #[rustversion::since(1.39)]
 fn main() {
     use ethcontract::transaction::Account;
@@ -8,6 +6,8 @@ fn main() {
     use web3::api::Web3;
     use web3::transports::Http;
     use web3::types::{Address, TransactionRequest, H256};
+
+    ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
 
     async fn print_balance_of(instance: &RustCoin, account: Address) {
         let balance = instance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@ mod test {
     pub mod transport;
 }
 
-#[cfg(feature = "example")]
+#[cfg(feature = "samples")]
 #[allow(missing_docs)]
-pub mod example {
-    //! An example of a derived contract for documentation purposes in roder to
+pub mod samples {
+    //! Samples of derived contracts for documentation purposes in roder to
     //! illustrate what the generated API. This module should not be used and is
     //! should only be included when generating documentation.
 

--- a/src/test/transport.rs
+++ b/src/test/transport.rs
@@ -10,11 +10,14 @@ use web3::futures::future::{self, FutureResult};
 use web3::helpers;
 use web3::{RequestId, Transport};
 
+/// Type alias for request method and value pairs
+type Requests = Vec<(String, Vec<Value>)>;
+
 /// Test transport
 #[derive(Debug, Default, Clone)]
 pub struct TestTransport {
     asserted: usize,
-    requests: Rc<RefCell<Vec<(String, Vec<Value>)>>>,
+    requests: Rc<RefCell<Requests>>,
     responses: Rc<RefCell<VecDeque<Value>>>,
 }
 


### PR DESCRIPTION
Rename the `example` feature to something else that is more descriptive and can't be confused with Cargo examples (as the feature is unrelated to Cargo examples).

also snuck in a small change to remove an unused dependency

Closes #27 