### PR TITLE
Async await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ethcontract-common = { version = "0.1.0", path = "./common" }
 ethcontract-derive = { version = "0.1.0", path = "./derive" }
 ethabi = "8.0"
 ethsign = "0.7"
-futures-preview = { version = "0.3.0-alpha.19", features = ["compat"] }
+futures = { version = "0.3.1", features = ["compat"] }
 jsonrpc-core = "11.0"
 lazy_static = "1.4"
 rlp = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,3 @@ serde_json = "1.0"
 thiserror = "1.0"
 tiny-keccak = "1.5"
 web3 = "0.8"
-
-[dev-dependencies]
-rustversion = "1.0"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ npm run develop
 Then in a sepate terminal window, you can run the example:
 
 ```sh
-$ cargo +beta run --example async
+$ cargo run --example async
 ```
 
 This example deploys a ERC20 token and interacts with the contract with various

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,98 +1,93 @@
+use ethcontract::transaction::Account;
+use ethsign::SecretKey;
+use futures::compat::Future01CompatExt;
+use web3::api::Web3;
+use web3::transports::Http;
+use web3::types::{Address, TransactionRequest, H256};
+
 ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
 
-#[rustversion::since(1.39)]
 fn main() {
-    use ethcontract::transaction::Account;
-    use ethsign::SecretKey;
-    use futures::compat::Future01CompatExt;
-    use web3::api::Web3;
-    use web3::transports::Http;
-    use web3::types::{Address, TransactionRequest, H256};
-
-    async fn print_balance_of(instance: &RustCoin, account: Address) {
-        let balance = instance
-            .balance_of(account)
-            .execute()
-            .await
-            .expect("balance of");
-        println!("Account {:?} has balance of {}", account, balance);
-    }
-
-    futures::executor::block_on(async {
-        let (eloop, http) = Http::new("http://localhost:7545").expect("transport");
-        eloop.into_remote();
-        let web3 = Web3::new(http);
-
-        let accounts = web3.eth().accounts().compat().await.expect("get accounts");
-
-        let instance = RustCoin::deploy(&web3)
-            .gas(4_712_388.into())
-            .confirmations(0)
-            .deploy()
-            .await
-            .expect("deploy");
-        let name = instance.name().execute().await.expect("name");
-        println!("Deployed {} at {:?}", name, instance.address());
-
-        instance
-            .transfer(accounts[1], 1_000_000.into())
-            .execute()
-            .await
-            .expect("transfer 0->1");
-        instance
-            .transfer(accounts[2], 500_000.into())
-            .from(Account::Local(accounts[1], None))
-            .execute()
-            .await
-            .expect("transfer 1->2");
-
-        print_balance_of(&instance, accounts[1]).await;
-        print_balance_of(&instance, accounts[2]).await;
-
-        let key = SecretKey::from_raw(
-            &"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-                .parse::<H256>()
-                .expect("valid hash")[..],
-        )
-        .expect("parse key");
-        let x: Address = key.public().address().into();
-        println!("Created new account {:?}", x);
-
-        // send some eth to x so that it can do transactions
-        web3.eth()
-            .send_transaction(TransactionRequest {
-                from: accounts[0],
-                to: Some(x),
-                gas: None,
-                gas_price: None,
-                value: Some(1_000_000_000_000_000_000u64.into()),
-                data: None,
-                nonce: None,
-                condition: None,
-            })
-            .compat()
-            .await
-            .expect("send eth");
-
-        instance
-            .transfer(x, 1_000_000.into())
-            .execute()
-            .await
-            .expect("transfer 0->x");
-        instance
-            .transfer(accounts[4], 420.into())
-            .from(Account::Offline(key, None))
-            .execute()
-            .await
-            .expect("transfer x->4");
-
-        print_balance_of(&instance, x).await;
-        print_balance_of(&instance, accounts[4]).await;
-    });
+    futures::executor::block_on(run());
 }
 
-#[rustversion::before(1.39)]
-fn main() {
-    eprintln!("Rust version ^1.39 required for async/await support.");
-    std::process::exit(-1);
+async fn run() {
+    let (eloop, http) = Http::new("http://localhost:7545").expect("transport");
+    eloop.into_remote();
+    let web3 = Web3::new(http);
+
+    let accounts = web3.eth().accounts().compat().await.expect("get accounts");
+
+    let instance = RustCoin::deploy(&web3)
+        .gas(4_712_388.into())
+        .confirmations(0)
+        .deploy()
+        .await
+        .expect("deploy");
+    let name = instance.name().execute().await.expect("name");
+    println!("Deployed {} at {:?}", name, instance.address());
+
+    instance
+        .transfer(accounts[1], 1_000_000.into())
+        .execute()
+        .await
+        .expect("transfer 0->1");
+    instance
+        .transfer(accounts[2], 500_000.into())
+        .from(Account::Local(accounts[1], None))
+        .execute()
+        .await
+        .expect("transfer 1->2");
+
+    print_balance_of(&instance, accounts[1]).await;
+    print_balance_of(&instance, accounts[2]).await;
+
+    let key = SecretKey::from_raw(
+        &"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            .parse::<H256>()
+            .expect("valid hash")[..],
+    )
+    .expect("parse key");
+    let x: Address = key.public().address().into();
+    println!("Created new account {:?}", x);
+
+    // send some eth to x so that it can do transactions
+    web3.eth()
+        .send_transaction(TransactionRequest {
+            from: accounts[0],
+            to: Some(x),
+            gas: None,
+            gas_price: None,
+            value: Some(1_000_000_000_000_000_000u64.into()),
+            data: None,
+            nonce: None,
+            condition: None,
+        })
+        .compat()
+        .await
+        .expect("send eth");
+
+    instance
+        .transfer(x, 1_000_000.into())
+        .execute()
+        .await
+        .expect("transfer 0->x");
+    instance
+        .transfer(accounts[4], 420.into())
+        .from(Account::Offline(key, None))
+        .execute()
+        .await
+        .expect("transfer x->4");
+
+    print_balance_of(&instance, x).await;
+    print_balance_of(&instance, accounts[4]).await;
+}
+
+async fn print_balance_of(instance: &RustCoin, account: Address) {
+    let balance = instance
+        .balance_of(account)
+        .execute()
+        .await
+        .expect("balance of");
+    println!("Account {:?} has balance of {}", account, balance);
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -91,16 +91,3 @@ impl<T: ?Sized> Default for PhantomDataUnpin<T> {
 // NOTE(nlordell): for some reason PhantomData is not always Unpin even if it is
 //   completely empty so should always be safe to move
 impl<T: ?Sized> Unpin for PhantomDataUnpin<T> {}
-
-// TODO(nlordell): remove once async/await stablalizes
-/// Temporary solution to async/await not being stable.
-pub trait FutureWaitExt: Future {
-    /// Block thread on a future completing.
-    fn wait(self) -> Self::Output;
-}
-
-impl<F: Future + Sized> FutureWaitExt for F {
-    fn wait(self) -> Self::Output {
-        futures::executor::block_on(self)
-    }
-}

--- a/src/test/prelude.rs
+++ b/src/test/prelude.rs
@@ -1,7 +1,21 @@
 //! Prelude module with common types used for unit tests.
 
-pub use crate::future::FutureWaitExt;
 pub use crate::test::macros::*;
 pub use crate::test::transport::TestTransport;
 pub use serde_json::json;
+use std::future::Future;
 pub use web3::api::Web3;
+
+/// Temporary solution to work around the issue that async tests are not stable
+/// and the extra boiler plate of setting up an executor is inconvenient.
+/// TODO(nlordell): remove once async tests stablalize
+pub trait FutureWaitExt: Future {
+    /// Block thread on a future completing.
+    fn wait(self) -> Self::Output;
+}
+
+impl<F: Future + Sized> FutureWaitExt for F {
+    fn wait(self) -> Self::Output {
+        futures::executor::block_on(self)
+    }
+}


### PR DESCRIPTION
Since async/await is now stabilized, we no longer need rust version guards on the example. Note that async tests are still unstable, so we're not 100% there yet.

### Test Plan
CI