### PR TITLE
[Easy] Contracts With Empty Bytecode Should Fail To Deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,3 @@ script:
   - cargo test --all-features --verbose --all
   - cargo fmt --all -- --check
   - cargo clippy --all --all-features --all-targets -- -D warnings
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
   - cargo test --all-features --verbose --all
   - cargo fmt --all -- --check
   - cargo clippy --all --all-features --all-targets -- -D warnings
+

--- a/common/src/truffle/bytecode.rs
+++ b/common/src/truffle/bytecode.rs
@@ -48,7 +48,7 @@ impl Bytecode {
             }
         }
 
-        Ok(Bytecode(s.to_string()))
+        Ok(Bytecode(s[2..].to_string()))
     }
 
     /// Link a library into the current bytecode.
@@ -83,7 +83,7 @@ impl Bytecode {
     pub fn into_bytes(self) -> Result<Bytes, LinkError> {
         match self.undefined_libraries().next() {
             Some(library) => Err(LinkError::UndefinedLibrary(library.to_string())),
-            None => Ok(Bytes(hex::decode(&self.0[2..]).expect("valid hex"))),
+            None => Ok(Bytes(hex::decode(&self.0).expect("valid hex"))),
         }
     }
 
@@ -99,7 +99,7 @@ impl Bytecode {
 
     /// Returns true if the bytecode is an empty bytecode.
     pub fn is_empty(&self) -> bool {
-        self.0 == "0x"
+        self.0 == ""
     }
 }
 
@@ -181,5 +181,18 @@ impl<'de> Visitor<'de> for BytecodeVisitor {
     {
         // TODO(nlordell): try to reuse this allocation
         self.visit_str(&v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_bytecode_is_empty() {
+        assert!(Bytecode::default().is_empty());
+    }
+
+    fn empty_hex_bytecode_is_empty() {
+        assert!(Bytecode::from_hex_str("0x").unwrap().is_empty());
     }
 }

--- a/common/src/truffle/bytecode.rs
+++ b/common/src/truffle/bytecode.rs
@@ -188,10 +188,12 @@ impl<'de> Visitor<'de> for BytecodeVisitor {
 mod tests {
     use super::*;
 
+    #[test]
     fn default_bytecode_is_empty() {
         assert!(Bytecode::default().is_empty());
     }
 
+    #[test]
     fn empty_hex_bytecode_is_empty() {
         assert!(Bytecode::from_hex_str("0x").unwrap().is_empty());
     }

--- a/common/src/truffle/bytecode.rs
+++ b/common/src/truffle/bytecode.rs
@@ -99,8 +99,7 @@ impl Bytecode {
 
     /// Returns true if the bytecode is an empty bytecode.
     pub fn is_empty(&self) -> bool {
-        // account for the 0x prefix
-        self.0.len() == 2
+        self.0 == "0x"
     }
 }
 

--- a/common/src/truffle/bytecode.rs
+++ b/common/src/truffle/bytecode.rs
@@ -96,6 +96,12 @@ impl Bytecode {
     pub fn requires_linking(&self) -> bool {
         self.undefined_libraries().next().is_some()
     }
+
+    /// Returns true if the bytecode is an empty bytecode.
+    pub fn is_empty(&self) -> bool {
+        // account for the 0x prefix
+        self.0.len() == 2
+    }
 }
 
 /// internal type for iterating though a bytecode's string code blocks skipping

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -195,6 +195,11 @@ fn expand_deployed(cx: &Context) -> TokenStream {
 }
 
 fn expand_deploy(cx: &Context) -> Result<TokenStream> {
+    if cx.artifact.bytecode.is_empty() {
+        // do not generate deploy method for contracts that have empty bytecode
+        return Ok(quote! {});
+    }
+
     let ethcontract = &cx.runtime_crate;
 
     // TODO(nlordell): not sure how contructor documentation get generated as I

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -328,4 +328,16 @@ mod tests {
         // TODO(nlordell): implement this test - there is an open issue for this
         //   on github
     }
+
+    #[test]
+    fn deploy_fails_on_empty_bytecode() {
+        let transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let artifact = Artifact::empty();
+        let error = DeployBuilder::<_, Instance<_>>::new(web3, artifact, ()).err().unwrap();
+
+        assert_eq!(error.to_string(), DeployError::EmptyBytecode.to_string());
+        transport.assert_no_more_requests();
+    }
 }

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -141,9 +141,12 @@ where
         //   `rust-web3` code so that we can add things like signing support;
         //   luckily most of complicated bits can be reused from the tx code
 
+        if artifact.bytecode.is_empty() {
+            return Err(DeployError::EmptyBytecode);
+        }
+
         let code = artifact.bytecode.into_bytes()?;
         let params = params.into_tokens();
-
         let data = match (artifact.abi.constructor(), params.is_empty()) {
             (None, false) => return Err(AbiErrorKind::InvalidData.into()),
             (None, true) => code,

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -335,7 +335,9 @@ mod tests {
         let web3 = Web3::new(transport.clone());
 
         let artifact = Artifact::empty();
-        let error = DeployBuilder::<_, Instance<_>>::new(web3, artifact, ()).err().unwrap();
+        let error = DeployBuilder::<_, Instance<_>>::new(web3, artifact, ())
+            .err()
+            .unwrap();
 
         assert_eq!(error.to_string(), DeployError::EmptyBytecode.to_string());
         transport.assert_no_more_requests();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,6 +26,11 @@ pub enum DeployError {
     #[error("could not link library {0}")]
     Link(#[from] LinkError),
 
+    /// Attempted to deploy a contract when empty bytecode. This can happen when
+    /// attempting to deploy a contract that is actually an interface.
+    #[error("can not deploy contract with empty bytecode")]
+    EmptyBytecode,
+
     /// An error occured encoding deployment parameters with the contract ABI.
     #[error("error ABI ecoding deployment parameters: {0}")]
     Abi(#[from] AbiError),

--- a/src/test/transport.rs
+++ b/src/test/transport.rs
@@ -68,7 +68,7 @@ impl TestTransport {
     }
 
     /// Assert that there are no more pending requests.
-    pub fn assert_no_more_requests(&mut self) {
+    pub fn assert_no_more_requests(&self) {
         let requests = self.requests.borrow();
         assert_eq!(
             self.asserted,


### PR DESCRIPTION
Solidity interfaces generate contract artifacts with empty bytecodes, these should not be deployable.