### PR TITLE
[Easy] Use Default Develop Network Settings For Truffle

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -12,7 +12,7 @@ fn main() {
 }
 
 async fn run() {
-    let (eloop, http) = Http::new("http://localhost:7545").expect("transport");
+    let (eloop, http) = Http::new("http://localhost:9545").expect("transport");
     eloop.into_remote();
     let web3 = Web3::new(http);
 

--- a/examples/truffle/truffle-config.js
+++ b/examples/truffle/truffle-config.js
@@ -2,13 +2,7 @@
 //! our rust examples.
 
 module.exports = {
-  networks: {
-    develop: {
-      host: "127.0.0.1",
-      port: 7545,
-      network_id: "*",
-    },
-  },
+  networks: { },
 
   mocha: { },
 


### PR DESCRIPTION
manually specifying a port is just unnecessary, this PR just removes some configuration and updates code accordingly.