### PR TITLE
Generate API Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "common",
   "derive",
   "generate",
+  "examples/generate",
 ]
 
 [dependencies]
@@ -32,7 +33,7 @@ ethcontract-common = { version = "0.1.0", path = "./common" }
 ethcontract-derive = { version = "0.1.0", path = "./derive" }
 ethabi = "8.0"
 ethsign = "0.7"
-futures = { version = "0.3.1", features = ["compat"] }
+futures = { version = "0.3", features = ["compat"] }
 jsonrpc-core = "11.0"
 lazy_static = "1.4"
 rlp = "0.4"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ ethcontract::contract!("path/to/truffle/build/contract/Contract.json");
 This will generate a new struct `ContractName` with contract generated methods
 for interacting with contract functions in a type-safe way.
 
+## Generator API
+
+As an alternative to the procedural macro, a generator API is provided for
+generating contract bindings from `build.rs` scripts. More information can be
+found in the `ethcontract-generate` [README](generate/README.md).
+
 ## Running the Examples
 
 In order to run local examples you need:
@@ -37,20 +43,27 @@ cd examples/truffle
 npm run build
 ```
 
-### Async Example
+### Truffle Examples
 
-This example deploys a ERC20 token and interacts with the contract with various
-accounts. First start the local development server:
+Truffle examples rely on the local truffle development server. In a separate
+terminal run:
 
 ```sh
 npm run develop
 ```
 
-Then in a sepate terminal window, you can run the example:
+- The async example deploys an ERC20 token and interacts with the contract with
+  various accounts. First start the local development server:
+  ```sh
+  cargo run --example async
+  ```
 
-```sh
-cargo run --example async
-```
+- The generator example (actually a separate crate to be able to have a build
+ script) demonstrates how the generator API can be used for creating type-safe
+ bindings to a smart contract with a `build.rs` build script.
+  ```sh
+  cargo run --package examples-generate
+  ```
 
 ### Rinkeby Example
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Truffle examples rely on the local truffle development server. In a separate
 terminal run:
 
 ```sh
-npm run develop
+npm start
 ```
 
 - The async example deploys an ERC20 token and interacts with the contract with

--- a/examples/generate/Cargo.toml
+++ b/examples/generate/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "examples-generate"
+version = "0.1.0"
+publish = false
+authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+ethcontract = { path = "../.." }
+futures = "0.3"
+web3 = "0.8"
+
+[build-dependencies]
+ethcontract-generate = { path = "../../generate" }

--- a/examples/generate/build.rs
+++ b/examples/generate/build.rs
@@ -1,0 +1,12 @@
+use ethcontract_generate::Builder;
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let dest = env::var("OUT_DIR").unwrap();
+    Builder::new("../truffle/build/contracts/RustCoin.json")
+        .generate()
+        .unwrap()
+        .write_to_file(Path::new(&dest).join("rust_coin.rs"))
+        .unwrap();
+}

--- a/examples/generate/src/main.rs
+++ b/examples/generate/src/main.rs
@@ -1,0 +1,32 @@
+#[allow(warnings, unused)]
+mod contract {
+    include!(concat!(env!("OUT_DIR"), "/rust_coin.rs"));
+}
+
+use crate::contract::RustCoin;
+use web3::api::Web3;
+use web3::transports::Http;
+
+fn main() {
+    futures::executor::block_on(run());
+}
+
+async fn run() {
+    let (eloop, http) = Http::new("http://localhost:9545").expect("create transport failed");
+    eloop.into_remote();
+    let web3 = Web3::new(http);
+
+    let instance = RustCoin::deploy(&web3)
+        .gas(4_712_388.into())
+        .confirmations(0)
+        .deploy()
+        .await
+        .expect("deployment failed");
+
+    println!(
+        "using {} ({}) at {:?}:",
+        instance.name().call().await.expect("get name failed"),
+        instance.symbol().call().await.expect("get name failed"),
+        instance.address()
+    );
+}

--- a/examples/truffle/README.md
+++ b/examples/truffle/README.md
@@ -42,7 +42,7 @@ export ETHERSCAN_API_KEY="Etherscan API key"
 
 In order to deploy, the following NPM script should be used:
 ```sh
-npm run
+npm run deploy
 ```
 
 This will:

--- a/generate/README.md
+++ b/generate/README.md
@@ -29,9 +29,16 @@ Then, in your `build.rs` include the following code:
 
 ```rs
 use ethcontract_generate::Builder;
+use std::env;
+use std::path::Path;
 
 fn main() {
-
+    let dest = env::var("OUT_DIR").unwrap();
+    Builder::new("path/to/truffle/build/contract/Contract.json")
+        .generate()
+        .unwrap()
+        .write_to_file(Path::new(&dest).join("rust_coin.rs"))
+        .unwrap();
 }
 ```
 

--- a/generate/README.md
+++ b/generate/README.md
@@ -1,0 +1,48 @@
+# `ethcontract-generate`
+
+An alternative API for generating type-safe contract bindings from `build.rs`
+scripts. Using this method instead of the procedural macro has a couple
+advantages:
+- Proper integration with with RLS and Racer for autocomplete support
+- Ability to inspect the generated code
+
+The downside of using the generator API is the requirement of having a build
+script instead of a macro invocation.
+
+## Getting Started
+
+Using crate requires two dependencies - one for the runtime and one for the
+generator:
+
+```toml
+[dependencies]
+ethcontract = "..."
+
+[build-dependencies]
+ethcontract-generate = "..."
+```
+
+It is recommended that both versions be kept in sync or else unexpected
+behaviour may occur.
+
+Then, in your `build.rs` include the following code:
+
+```rs
+use ethcontract_generate::Builder;
+
+fn main() {
+
+}
+```
+
+## Relation to `ethcontract-derive`
+
+`ethcontract-derive` uses `ethcontract-generate` under the hood so their
+generated bindings should be identical, they just provide different APIs to the
+same functionality.
+
+The long term goal of this project is to maintain `ethcontract-derive`. For now
+there is no extra work in having it split into two separate crates. That being
+said if RLS support improves for procedural macro generated code, it is possible
+that this crate be deprecated in favour of `ethcontract-derive` as long as there
+is no good argument to keep it around.


### PR DESCRIPTION
Adds an example to illustrate how to use the `ethcontract-generate` API with a build script.

### Test Plan

new example