### PR TITLE
Suppress Compiler Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ npm start
   ```
 
 - The `generator` example (actually a separate crate to be able to have a build
- script) demonstrates how the generator API can be used for creating type-safe
- bindings to a smart contract with a `build.rs` build script.
+  script) demonstrates how the generator API can be used for creating type-safe
+  bindings to a smart contract with a `build.rs` build script.
   ```sh
   cargo run --package examples-generate
   ```

--- a/examples/generate/src/main.rs
+++ b/examples/generate/src/main.rs
@@ -1,11 +1,7 @@
-#[allow(warnings, unused)]
-mod contract {
-    include!(concat!(env!("OUT_DIR"), "/rust_coin.rs"));
-}
-
-use crate::contract::RustCoin;
 use web3::api::Web3;
 use web3::transports::Http;
+
+include!(concat!(env!("OUT_DIR"), "/rust_coin.rs"));
 
 fn main() {
     futures::executor::block_on(run());
@@ -24,7 +20,7 @@ async fn run() {
         .expect("deployment failed");
 
     println!(
-        "using {} ({}) at {:?}:",
+        "using {} ({}) at {:?}",
         instance.name().call().await.expect("get name failed"),
         instance.symbol().call().await.expect("get name failed"),
         instance.address()

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -71,12 +71,10 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
 
     Ok(quote! {
         #doc
-        #[allow(warnings)]
         pub struct #contract_name {
             instance: #ethcontract::DynInstance,
         }
 
-        #[allow(warnings, unused)]
         impl #contract_name {
             /// Retrieves the truffle artifact used to generate the type safe API
             /// for this contract.
@@ -361,7 +359,7 @@ fn expand_inputs_call_arg(inputs: &[Param]) -> TokenStream {
         .iter()
         .enumerate()
         .map(|(i, param)| expand_input_name(i, &param.name));
-    quote! { ( #( #names ),* ) }
+    quote! { ( #( #names ,)* ) }
 }
 
 fn expand_fn_outputs(cx: &Context, function: &Function) -> Result<TokenStream> {

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -71,10 +71,12 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
 
     Ok(quote! {
         #doc
+        #[allow(warnings)]
         pub struct #contract_name {
             instance: #ethcontract::DynInstance,
         }
 
+        #[allow(warnings, unused)]
         impl #contract_name {
             /// Retrieves the truffle artifact used to generate the type safe API
             /// for this contract.

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -71,10 +71,12 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
 
     Ok(quote! {
         #doc
+        #[allow(non_camel_case_types)]
         pub struct #contract_name {
             instance: #ethcontract::DynInstance,
         }
 
+        #[allow(dead_code)]
         impl #contract_name {
             /// Retrieves the truffle artifact used to generate the type safe API
             /// for this contract.


### PR DESCRIPTION
Add attributes to the generated code to suppress compiler warnings on generated code.