### PR TITLE
[Easy] Remove `PhantomDataUnpin`

### DIFF
--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -3,13 +3,14 @@
 
 use crate::contract::Instance;
 use crate::errors::DeployError;
-use crate::future::{CompatCallFuture, PhantomDataUnpin, Web3Unpin};
+use crate::future::{CompatCallFuture, Web3Unpin};
 use crate::transaction::{Account, SendAndConfirmFuture, TransactionBuilder};
 use crate::truffle::{Abi, Artifact};
 use ethabi::ErrorKind as AbiErrorKind;
 use futures::compat::Future01CompatExt;
 use futures::ready;
 use std::future::Future;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -43,7 +44,7 @@ where
     args: Option<(Web3Unpin<T>, Artifact)>,
     /// Underlying future for retrieving the network ID.
     network_id: CompatCallFuture<T, String>,
-    _deploy: PhantomDataUnpin<D>,
+    _deploy: PhantomData<Box<D>>,
 }
 
 impl<T, D> DeployedFuture<T, D>
@@ -119,7 +120,7 @@ where
     pub poll_interval: Option<Duration>,
     /// The number of confirmations to wait for.
     pub confirmations: Option<usize>,
-    _deploy: PhantomDataUnpin<D>,
+    _deploy: PhantomData<Box<D>>,
 }
 
 impl<T, D> DeployBuilder<T, D>
@@ -236,7 +237,7 @@ where
     args: Option<(Web3Unpin<T>, Abi)>,
     /// The future resolved when the deploy transaction is complete.
     tx: Result<SendAndConfirmFuture<T>, Option<DeployError>>,
-    _deploy: PhantomDataUnpin<D>,
+    _deploy: PhantomData<Box<D>>,
 }
 
 impl<T, D> DeployFuture<T, D>

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,7 +1,6 @@
 use futures::compat::Compat01As03;
 use futures::future::{self, Either, Ready};
 use std::future::Future;
-use std::marker::PhantomData;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -77,17 +76,3 @@ pub type CompatQueryResult<T, R> = Compat01As03<QueryResult<R, <T as Transport>:
 
 /// Type alias for Compat01As03<SendTransactionWithConfirmation<...>>.
 pub type CompatSendTxWithConfirmation<T> = Compat01As03<SendTransactionWithConfirmation<T>>;
-
-/// A helper type for PhantomData that also implements Unpin.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct PhantomDataUnpin<T: ?Sized>(PhantomData<T>);
-
-impl<T: ?Sized> Default for PhantomDataUnpin<T> {
-    fn default() -> Self {
-        PhantomDataUnpin(PhantomData)
-    }
-}
-
-// NOTE(nlordell): for some reason PhantomData is not always Unpin even if it is
-//   completely empty so should always be safe to move
-impl<T: ?Sized> Unpin for PhantomDataUnpin<T> {}


### PR DESCRIPTION
Minor misuse of `PhantomData`. This PR just cleans that up and uses a better solution.

### Test Plan

CI still passes.