### PR TITLE
[Easy] Change Order of `deploy` Method Parameters

### DIFF
--- a/examples/linked.rs
+++ b/examples/linked.rs
@@ -19,7 +19,7 @@ async fn run() {
         .deploy()
         .await
         .expect("library deployment failure");
-    let instance = LinkedContract::deploy(&web3, 1337.into(), library.address())
+    let instance = LinkedContract::deploy(&web3, library.address(), 1337.into())
         .gas(4_712_388.into())
         .confirmations(0)
         .deploy()

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -252,7 +252,7 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
     Ok(quote! {
         #doc
         pub fn deploy<F, T>(
-            web3: &#ethcontract::web3::api::Web3<T> #input #lib_input ,
+            web3: &#ethcontract::web3::api::Web3<T> #lib_input #input ,
         ) -> #ethcontract::DynDeployBuilder<Self>
         where
             F: #ethcontract::web3::futures::Future<Item = #ethcontract::json::Value, Error = #ethcontract::web3::Error> + Send + 'static,


### PR DESCRIPTION
RIght now, we are generating bindings that look like this `deploy(web3, constructor_params, library_addresses)`, and conceptually it makes more sense to do `deploy(web3, library_addresses, contructor_params)`.

### Test Plan

CI