### PR TITLE
Work Around Estimate Gas Issue With Geth Nodes

### DIFF
--- a/examples/rinkeby.rs
+++ b/examples/rinkeby.rs
@@ -49,7 +49,6 @@ async fn run() {
     instance
         .increment()
         .from(account.clone())
-        .gas(1_000_000.into())
         .send_and_confirm(Duration::new(5, 0), 1)
         .await
         .expect("increment failed");


### PR DESCRIPTION
This implements a workaround to tomusdrw/rust-web3#290. While the issue has been fixed on master, it has not been released to crates.io.

Fixes #47 

### Test Plan

CI