### PR TITLE
API To Set Default Method Options

### DIFF
--- a/examples/rinkeby.rs
+++ b/examples/rinkeby.rs
@@ -43,11 +43,7 @@ async fn run() {
 
     println!(
         "  value before: {}",
-        instance
-            .value()
-            .call()
-            .await
-            .expect("get value failed")
+        instance.value().call().await.expect("get value failed")
     );
     println!("  incrementing (this may take a while)...");
     instance
@@ -57,10 +53,6 @@ async fn run() {
         .expect("increment failed");
     println!(
         "  value after: {}",
-        instance
-            .value()
-            .call()
-            .await
-            .expect("get value failed")
+        instance.value().call().await.expect("get value failed")
     );
 }

--- a/examples/rinkeby.rs
+++ b/examples/rinkeby.rs
@@ -31,16 +31,20 @@ async fn run() {
     eloop.into_remote();
     let web3 = Web3::new(ws);
 
-    let instance = DeployedContract::deployed(&web3)
-        .await
-        .expect("locating deployed contract failed");
-
     println!("Account {:?}", account.address());
+
+    let instance = {
+        let mut instance = DeployedContract::deployed(&web3)
+            .await
+            .expect("locating deployed contract failed");
+        instance.defaults_mut().from = Some(account);
+        instance
+    };
+
     println!(
         "  value before: {}",
         instance
             .value()
-            .from(account.address())
             .call()
             .await
             .expect("get value failed")
@@ -48,7 +52,6 @@ async fn run() {
     println!("  incrementing (this may take a while)...");
     instance
         .increment()
-        .from(account.clone())
         .send_and_confirm(Duration::new(5, 0), 1)
         .await
         .expect("increment failed");
@@ -56,7 +59,6 @@ async fn run() {
         "  value after: {}",
         instance
             .value()
-            .from(account.address())
             .call()
             .await
             .expect("get value failed")

--- a/examples/rinkeby.rs
+++ b/examples/rinkeby.rs
@@ -37,7 +37,7 @@ async fn run() {
         let mut instance = DeployedContract::deployed(&web3)
             .await
             .expect("locating deployed contract failed");
-        instance.defaults_mut().from = Some(account);
+        instance.base_instance_mut().defaults.from = Some(account);
         instance
     };
 

--- a/examples/rinkeby.rs
+++ b/examples/rinkeby.rs
@@ -37,7 +37,7 @@ async fn run() {
         let mut instance = DeployedContract::deployed(&web3)
             .await
             .expect("locating deployed contract failed");
-        instance.base_instance_mut().defaults.from = Some(account);
+        instance.defaults_mut().from = Some(account);
         instance
     };
 

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -123,6 +123,12 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
                 &self.instance
             }
 
+            /// Retrieve a mutable reference to the undelying instance being
+            /// used by this contract.
+            pub fn instance_mut(&self) -> &mut #ethcontract::DynInstance {
+                &mut self.instance
+            }
+
             /// Returns the contract address being used by this instance.
             pub fn address(&self) -> #ethcontract::web3::types::Address {
                 self.instance.address()
@@ -131,17 +137,6 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
             #deployed
 
             #deploy
-
-            /// Retrieve a reference to the contract instance's method defaults.
-            pub fn defaults(&self) -> &#ethcontract::contract::MethodDefaults {
-                &self.instance.defaults
-            }
-
-            /// Retrieve a mutable reference to the contract instance's method
-            /// defaults.
-            pub fn defaults_mut(&mut self) -> &mut #ethcontract::contract::MethodDefaults {
-                &mut self.instance.defaults
-            }
 
             #( #functions )*
         }

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -118,14 +118,15 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
                 Self{ instance }
             }
 
-            /// Retrieve the undelying instance being used by this contract.
-            pub fn instance(&self) -> &#ethcontract::DynInstance {
+            /// Retrieve a reference the undelying base `ethcontract::Instance`
+            /// being used by this contract.
+            pub fn base_instance(&self) -> &#ethcontract::DynInstance {
                 &self.instance
             }
 
-            /// Retrieve a mutable reference to the undelying instance being
-            /// used by this contract.
-            pub fn instance_mut(&self) -> &mut #ethcontract::DynInstance {
+            /// Retrieve a mutable reference the undelying base
+            /// `ethcontract::Instance` being used by this contract.
+            pub fn base_instance_mut(&mut self) -> &mut #ethcontract::DynInstance {
                 &mut self.instance
             }
 

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -132,6 +132,17 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
 
             #deploy
 
+            /// Retrieve a reference to the contract instance's method defaults.
+            pub fn defaults(&self) -> &#ethcontract::contract::MethodDefaults {
+                &self.instance.defaults
+            }
+
+            /// Retrieve a mutable reference to the contract instance's method
+            /// defaults.
+            pub fn defaults_mut(&mut self) -> &mut #ethcontract::contract::MethodDefaults {
+                &mut self.instance.defaults
+            }
+
             #( #functions )*
         }
 

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -118,21 +118,21 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
                 Self{ instance }
             }
 
-            /// Retrieve a reference the undelying base `ethcontract::Instance`
-            /// being used by this contract.
-            pub fn base_instance(&self) -> &#ethcontract::DynInstance {
-                &self.instance
-            }
-
-            /// Retrieve a mutable reference the undelying base
-            /// `ethcontract::Instance` being used by this contract.
-            pub fn base_instance_mut(&mut self) -> &mut #ethcontract::DynInstance {
-                &mut self.instance
-            }
-
             /// Returns the contract address being used by this instance.
             pub fn address(&self) -> #ethcontract::web3::types::Address {
                 self.instance.address()
+            }
+
+            /// Returns a reference to the default method options used by this
+            /// contract.
+            pub fn defaults(&self) -> &#ethcontract::contract::MethodDefaults {
+                &self.instance.defaults
+            }
+
+            /// Returns a mutable reference to the default method options used
+            /// by this contract.
+            pub fn defaults_mut(&mut self) -> &mut #ethcontract::contract::MethodDefaults {
+                &mut self.instance.defaults
             }
 
             #deployed

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -18,6 +18,17 @@ use web3::contract::QueryResult;
 use web3::types::{Address, BlockNumber, Bytes, CallRequest, U256};
 use web3::Transport;
 
+/// Default options to be applied to `MethodBuilder` or `ViewMethodBuilder`.
+#[derive(Clone, Debug, Default)]
+pub struct MethodDefaults {
+    /// Default sender of the transaction with the signing strategy to use.
+    pub from: Option<Account>,
+    /// Default gas amount to use for transaction.
+    pub gas: Option<U256>,
+    /// Default gas price to use for transaction.
+    pub gas_price: Option<U256>,
+}
+
 /// Data used for building a contract method call or transaction. The method
 /// builder can be demoted into a `CallBuilder` to not allow sending of
 /// transactions. This is useful when dealing with view functions.
@@ -45,6 +56,14 @@ impl<T: Transport, R: Detokenize> MethodBuilder<T, R> {
             tx: TransactionBuilder::new(web3).to(address).data(data),
             _result: PhantomData,
         }
+    }
+
+    /// Apply method defaults to this builder.
+    pub fn with_defaults(mut self, defaults: &MethodDefaults) -> MethodBuilder<T, R> {
+        self.tx.from = self.tx.from.or(defaults.from.clone());
+        self.tx.gas = self.tx.gas.or(defaults.gas);
+        self.tx.gas_price = self.tx.gas_price.or(defaults.gas_price);
+        self
     }
 
     /// Specify the signing method to use for the transaction, if not specified
@@ -136,6 +155,12 @@ impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
             m: method,
             block: None,
         }
+    }
+
+    /// Apply method defaults to this builder.
+    pub fn with_defaults(mut self, defaults: &MethodDefaults) -> ViewMethodBuilder<T, R> {
+        self.m = self.m.with_defaults(defaults);
+        self
     }
 
     /// Specify the account the transaction is being sent from.

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -60,7 +60,7 @@ impl<T: Transport, R: Detokenize> MethodBuilder<T, R> {
 
     /// Apply method defaults to this builder.
     pub fn with_defaults(mut self, defaults: &MethodDefaults) -> MethodBuilder<T, R> {
-        self.tx.from = self.tx.from.or(defaults.from.clone());
+        self.tx.from = self.tx.from.or_else(|| defaults.from.clone());
         self.tx.gas = self.tx.gas.or(defaults.gas);
         self.tx.gas_price = self.tx.gas_price.or(defaults.gas_price);
         self


### PR DESCRIPTION
API so instances can set default method options. This allows the contract instance to store information such as default account and signing strategy to be used by methods.

This feature would be useful for dex-services and closes #51 

### Test Plan

Used in `rinkeby` example.