### PR TITLE
Fix Library Linking When It Appears Multiple Times In The Bytecode

### DIFF
--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -60,10 +60,10 @@ mod tests {
         for (value, matched, expected) in &[
             ("abcdefg", false, "abcdefg"),
             ("abfoocdefg", true, "abbarcdefg"),
-            ("abfoocdfooefgfoo", true, "abbarcdfooefgfoo"),
+            ("abfoocdfooefgfoo", true, "abbarcdbarefgbar"),
         ] {
             let mut value = (*value).to_string();
-            assert_eq!(value.replace_once_in_place("foo", "bar"), *matched);
+            assert_eq!(value.replace_all_in_place("foo", "bar"), *matched);
             assert_eq!(&value, expected);
         }
     }

--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -4,7 +4,7 @@ use web3::types::Address;
 
 /// Extension trait for in place `String` replacement.
 pub trait StringReplaceExt {
-    /// Replace a single match of a pattern string with another.
+    /// Replace all matches of a pattern string with another.
     ///
     /// # Returns
     ///

--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -13,27 +13,29 @@ pub trait StringReplaceExt {
     /// # Panics
     ///
     /// Panics if the replacement string size does not match the search pattern.
-    fn replace_once_in_place(&mut self, from: &str, to: &str) -> bool;
+    fn replace_all_in_place(&mut self, from: &str, to: &str) -> bool;
 }
 
 impl StringReplaceExt for String {
-    fn replace_once_in_place(&mut self, from: &str, to: &str) -> bool {
+    fn replace_all_in_place(&mut self, from: &str, to: &str) -> bool {
         let len = from.len();
         if to.len() != len {
             panic!("mismatch length of from and to string");
         }
 
-        if let Some(start) = self.find(from) {
+        let mut found = false;
+        while let Some(start) = self.find(from) {
             let end = start + len;
 
-            // NOTE(nlordell): safe since the to string is valid utf-8
+            // NOTE(nlordell): safe since the to string is valid utf-8 and
+            //   `str::len()` returns byte length and not character length
             let section = unsafe { self[start..end].as_bytes_mut() };
             section.copy_from_slice(to.as_bytes());
 
-            true
-        } else {
-            false
+            found = true
         }
+
+        found
     }
 }
 

--- a/common/src/truffle/bytecode.rs
+++ b/common/src/truffle/bytecode.rs
@@ -145,7 +145,7 @@ impl<'a> Iterator for LibIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(pos) = self.cursor.find("__") {
-            // NOTE(nlordell): this won't panic since we only constrcut this iterator
+            // NOTE(nlordell): this won't panic since we only construct this iterator
             //   on valid Bytecode instances where this has been verified
             let (placeholder, tail) = self.cursor[pos..].split_at(40);
             let lib = placeholder.trim_matches('_');

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -216,7 +216,6 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
         None => (quote! {}, quote! {()}),
     };
 
-    // TODO(nlordell): we don't handle duplicate library names
     let lib_params: Vec<_> = cx
         .artifact
         .bytecode


### PR DESCRIPTION
The linking code made an incorrect assumption that library addresses were only present once in the bytecode, but this is not true, for example when using inherited contracts that use the same library. This PR links all instances of a library.

### Test Plan

CI