### PR TITLE
Fix Type Mappings

### DIFF
--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -385,7 +385,7 @@ fn expand_type(cx: &Context, kind: &ParamType) -> Result<TokenStream> {
     match kind {
         ParamType::Address => Ok(quote! { #ethcontract::web3::types::Address }),
         ParamType::Bytes => Ok(quote! { Vec<u8> }),
-        ParamType::Int(n) | ParamType::Uint(n) => match n/8 {
+        ParamType::Int(n) | ParamType::Uint(n) => match n / 8 {
             // TODO(nlordell): for now, not all uint/int types implement the
             //   `Tokenizable` trait, only `u64`, `U128`, and `U256` so we need
             //   to map solidity int/uint types to those; eventually we should

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -384,16 +384,16 @@ fn expand_type(cx: &Context, kind: &ParamType) -> Result<TokenStream> {
 
     match kind {
         ParamType::Address => Ok(quote! { #ethcontract::web3::types::Address }),
-        ParamType::Bytes => Ok(quote! { #ethcontract::web3::types::Bytes }),
-        ParamType::Int(n) | ParamType::Uint(n) => match n {
+        ParamType::Bytes => Ok(quote! { Vec<u8> }),
+        ParamType::Int(n) | ParamType::Uint(n) => match n/8 {
             // TODO(nlordell): for now, not all uint/int types implement the
             //   `Tokenizable` trait, only `u64`, `U128`, and `U256` so we need
             //   to map solidity int/uint types to those; eventually we should
             //   add more implementations to the `web3` crate
-            8 | 16 | 32 | 64 => Ok(quote! { u64 }),
-            128 => Ok(quote! { #ethcontract::web3::types::U128 }),
-            256 => Ok(quote! { #ethcontract::web3::types::U256 }),
-            n => Err(anyhow!("unsupported solidity type int{}", n)),
+            1..=8 => Ok(quote! { u64 }),
+            9..=16 => Ok(quote! { #ethcontract::web3::types::U128 }),
+            17..=32 => Ok(quote! { #ethcontract::web3::types::U256 }),
+            _ => Err(anyhow!("unsupported solidity type int{}", n)),
         },
         ParamType::Bool => Ok(quote! { bool }),
         ParamType::String => Ok(quote! { String }),


### PR DESCRIPTION
Add type mappings between more `u?int(.*)` types and rust types and fix type mapping for variable length byte arrays.

### Test Plan

dex-services