### PR TITLE
Speed up Travis CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,26 @@ jobs:
       script:
         - (cd examples/truffle; npm run build)
         - docker run -d -p 9545:8545 trufflesuite/ganache-cli:v6.7.0
-        - cargo run --example async
-        - cargo run --example linked
-        - cargo run --package examples-generate
-        - cargo run --example rinkeby
+        - RUSTC_WRAPPER=sccache cargo run --example async
+        - RUSTC_WRAPPER=sccache cargo run --example linked
+        - RUSTC_WRAPPER=sccache cargo run --package examples-generate
+        - RUSTC_WRAPPER=sccache cargo run --example rinkeby
 
 cache:
   directories:
+    - $HOME/.cache/sccache
     - $HOME/.cargo
     - $HOME/.npm
     - $HOME/.rustup
 
 before_install:
   - rustup component add clippy rustfmt
+  - cargo clippy --version
+  - cargo fmt --version
+  - cargo install cargo-update || echo "cargo-update already installed"
+  - cargo install sccache || echo "sccache already installed"
+  - cargo install-update -a
+  - sccache --version
   - nvm install stable && nvm alias default stable
   - node --version
   - npm install -g npm@latest
@@ -45,7 +52,10 @@ install:
 
 script:
   - (cd examples/truffle; npm run build)
-  - cargo build --all-features --verbose --all
-  - cargo test --all-features --verbose --all
-  - cargo fmt --all -- --check
-  - cargo clippy --all --all-features --all-targets -- -D warnings
+  - RUSTC_WRAPPER=sccache cargo build --all-features --verbose --all
+  - RUSTC_WRAPPER=sccache cargo test --all-features --verbose --all
+  - RUSTC_WRAPPER=sccache cargo fmt --all -- --check
+  - RUSTC_WRAPPER=sccache cargo clippy --all --all-features --all-targets -- -D warnings
+
+before_cache:
+  - rm -rf "$TRAVIS_HOME/.cargo/registry"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,13 @@ cache:
     - $HOME/.rustup
 
 before_install:
+  - rustup toolchain add stable
   - rustup component add clippy rustfmt
   - cargo clippy --version
   - cargo fmt --version
-  - cargo install cargo-update || echo "cargo-update already installed"
-  - cargo install sccache || echo "sccache already installed"
-  - cargo install-update -a
+  - cargo +stable install cargo-update || echo "cargo-update already installed"
+  - cargo +stable install sccache || echo "sccache already installed"
+  - cargo +stable install-update -a
   - sccache --version
   - nvm install stable && nvm alias default stable
   - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ jobs:
         - cargo run --example rinkeby
 
 cache:
-  cargo: true
   directories:
+    - $HOME/.cargo
     - $HOME/.npm
+    - $HOME/.rustup
 
 before_install:
   - rustup component add clippy rustfmt


### PR DESCRIPTION
Builds are currently taking ~20 minutes which is excessive for a library of this size. It appears to be spending about 75% of the time downloading and uploading cache. From what I have read, not caching `target/` for libraries without a `Cargo.lock` makes a lot of sense as it grows really quickly and doesn't provide much benefits.

Ironically builds with cache misses (because cache was cleared) were much faster. [This one](https://travis-ci.org/gnosis/ethcontract-rs/jobs/626203145) lasted only ~8.5 minutes.

### Changes

- [x] No longer cache `target/`: this is the biggest change as the target directory grows very quickly and causes caches to grow to around 8GB. This this the major cause of slow down.
- [x] No longer cache `.cargo/registry`: this also grows as dependencies get resolved to different versions and it can be argued that it is better to download from crates.io as then only the required sources are needed. Additionally, there is no point in keeping a cached crates.io index as this repo does not have a `Cargo.lock` and so will download the index on every build anyway.
- [x] Use sccache: This caches compiled rust artifacts, similar to caching `target/` but in a way that is optimized for cloud storage. This allows dependencies to not be rebuilt while keeping the cache significantly smaller than when caching `target/`

### Test Plan

The average build time for the last 10 builds without cache misses at the time of writing was 19m 57s, the plan is to lower this number.