### PR TITLE
[Easy] Allow Functinos With too Many Arguments and Complex Types

### DIFF
--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -77,6 +77,7 @@ pub(crate) fn expand_contract(args: &Args) -> Result<TokenStream> {
         }
 
         #[allow(dead_code)]
+        #[allow(clippy::too_many_arguments, clippy::type_complexity)]
         impl #contract_name {
             /// Retrieves the truffle artifact used to generate the type safe API
             /// for this contract.


### PR DESCRIPTION
This just disables some clippy warnings on generated code for things that cannot be changed (like functions with too many arguments or return values).

### Test Plan

dex-services