### PR TITLE
Support `revert(string)` and `revert()` and `invalid()` for `eth_call`

### DIFF
--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -247,6 +247,14 @@ lazy_static! {
     static ref ERROR_SELECTOR: [u8; 4] = hash::function_selector("Error(string)");
 }
 
+/// Decodes the raw bytes result from an `eth_call` request to check for reverts
+/// and encoded revert messages.
+///
+/// This is required since Geth returns a success result from an `eth_call` that
+/// reverts (or if an invalid opcode is executed) while other nodes like Ganache
+/// encode this information in a JSON RPC error. On a revert of invalid opcode,
+/// the result is a `0x` empty data while on a revert with message, it is an ABI
+/// encoded `Error(string)` function call data.
 fn decode_geth_call_result<R: Detokenize>(
     function: &Function,
     bytes: Vec<u8>,
@@ -255,8 +263,8 @@ fn decode_geth_call_result<R: Detokenize>(
         // Geth does this on `revert()` without a message and `invalid()`,
         // just treat them all as `invalid()` as generally contracts revert
         // with messages.
-        Err(ExecutionError::CallInvalidOpcode)
-    } else if (bytes.len() + 28) % 32 == 0 && &bytes[0..4] == &ERROR_SELECTOR[..] {
+        Err(ExecutionError::InvalidOpcode)
+    } else if (bytes.len() + 28) % 32 == 0 && bytes[0..4] == ERROR_SELECTOR[..] {
         // check to make sure that the length is of the form `4 + n * 32`
         // bytes and it starts with `keccak256("Error(string)")` which means
         // it is an encoded revert message from Geth nodes.
@@ -266,9 +274,9 @@ fn decode_geth_call_result<R: Detokenize>(
             .to_string()
             .expect("decoded string parameter will always be a string");
 
-        Err(ExecutionError::CallRevert(Some(message)))
+        Err(ExecutionError::Revert(Some(message)))
     } else {
-        // try and decode the result.
+        // just a plain ol' regular result, try and decode it
         let result = R::from_tokens(function.decode_output(&bytes)?)?;
         Ok(result)
     }
@@ -434,6 +442,34 @@ mod tests {
     }
 
     #[test]
+    fn method_call_geth_revert_with_message() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let address = addr!("0x0123456789012345678901234567890123456789");
+        let (function, data) = test_abi_function();
+        let tx = ViewMethodBuilder::<_, U256>::from_method(MethodBuilder::new(
+            web3,
+            function,
+            address,
+            data,
+        ));
+
+        transport.add_response(json!(
+            "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000076d65737361676500000000000000000000000000000000000000000000000000"
+        )); // call response
+        let result = tx.call().wait();
+        assert!(
+            match &result {
+                Err(ExecutionError::Revert(Some(ref reason))) if reason == "message" => true,
+                _ => false,
+            },
+            "unexpected result {:?}",
+            result
+        );
+    }
+
+    #[test]
     fn method_call_geth_revert() {
         let mut transport = TestTransport::new();
         let web3 = Web3::new(transport.clone());
@@ -444,27 +480,14 @@ mod tests {
             web3,
             function,
             address,
-            data.clone(),
+            data,
         ));
-
-        transport.add_response(json!(
-            "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000076d65737361676500000000000000000000000000000000000000000000000000"
-        )); // call response
-        let result = tx.clone().call().wait();
-        assert!(
-            match &result {
-                Err(ExecutionError::CallRevert(Some(ref message))) if message == "message" => true,
-                _ => false,
-            },
-            "unexpected result {:?}",
-            result
-        );
 
         transport.add_response(json!("0x"));
         let result = tx.call().wait();
         assert!(
             match &result {
-                Err(ExecutionError::CallInvalidOpcode) => true,
+                Err(ExecutionError::InvalidOpcode) => true,
                 _ => false,
             },
             "unexpected result {:?}",

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -244,6 +244,7 @@ impl<T: Transport, R: Detokenize> CallFuture<T, R> {
 }
 
 lazy_static! {
+    /// The ABI function selector for identifying encoded revert messages.
     static ref ERROR_SELECTOR: [u8; 4] = hash::function_selector("Error(string)");
 }
 

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -253,9 +253,9 @@ lazy_static! {
 ///
 /// This is required since Geth returns a success result from an `eth_call` that
 /// reverts (or if an invalid opcode is executed) while other nodes like Ganache
-/// encode this information in a JSON RPC error. On a revert of invalid opcode,
-/// the result is a `0x` empty data while on a revert with message, it is an ABI
-/// encoded `Error(string)` function call data.
+/// encode this information in a JSON RPC error. On a revert or invalid opcode,
+/// the result is `0x` (empty data), while on a revert with message, it is an
+/// ABI encoded `Error(string)` function call data.
 fn decode_geth_call_result<R: Detokenize>(
     function: &Function,
     bytes: Vec<u8>,
@@ -266,7 +266,7 @@ fn decode_geth_call_result<R: Detokenize>(
         // with messages.
         Err(ExecutionError::InvalidOpcode)
     } else if (bytes.len() + 28) % 32 == 0 && bytes[0..4] == ERROR_SELECTOR[..] {
-        // check to make sure that the length is of the form `4 + n * 32`
+        // check to make sure that the length is of the form `4 + (n * 32)`
         // bytes and it starts with `keccak256("Error(string)")` which means
         // it is an encoded revert message from Geth nodes.
         let message = abi::decode(&[ParamType::String], &bytes[4..])?

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -450,10 +450,7 @@ mod tests {
         let address = addr!("0x0123456789012345678901234567890123456789");
         let (function, data) = test_abi_function();
         let tx = ViewMethodBuilder::<_, U256>::from_method(MethodBuilder::new(
-            web3,
-            function,
-            address,
-            data,
+            web3, function, address, data,
         ));
 
         transport.add_response(json!(
@@ -478,10 +475,7 @@ mod tests {
         let address = addr!("0x0123456789012345678901234567890123456789");
         let (function, data) = test_abi_function();
         let tx = ViewMethodBuilder::<_, U256>::from_method(MethodBuilder::new(
-            web3,
-            function,
-            address,
-            data,
+            web3, function, address, data,
         ));
 
         transport.add_response(json!("0x"));

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -3,10 +3,13 @@
 //! [Instance::method](ethcontract::contract::Instance::method).
 
 use crate::errors::ExecutionError;
-use crate::future::CompatQueryResult;
+use crate::future::CompatCallFuture;
+use crate::hash;
 use crate::transaction::{Account, SendAndConfirmFuture, SendFuture, TransactionBuilder};
-use crate::truffle::abi::Function;
+use crate::truffle::abi::{self, Function, ParamType};
 use futures::compat::Future01CompatExt;
+use futures::ready;
+use lazy_static::lazy_static;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -14,7 +17,6 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use web3::api::Web3;
 use web3::contract::tokens::Detokenize;
-use web3::contract::QueryResult;
 use web3::types::{Address, BlockNumber, Bytes, CallRequest, U256};
 use web3::Transport;
 
@@ -209,14 +211,22 @@ impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
 /// Future representing a pending contract call (i.e. query) to be resolved when
 /// the call completes.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct CallFuture<T: Transport, R: Detokenize>(CompatQueryResult<T, R>);
+pub struct CallFuture<T: Transport, R: Detokenize> {
+    function: Function,
+    call: CompatCallFuture<T, Bytes>,
+    _result: PhantomData<Box<R>>,
+}
 
 impl<T: Transport, R: Detokenize> CallFuture<T, R> {
     /// Construct a new `CallFuture` from a `CallBuilder`.
     fn from_builder(builder: ViewMethodBuilder<T, R>) -> CallFuture<T, R> {
-        CallFuture(
-            QueryResult::new(
-                builder.m.web3.eth().call(
+        CallFuture {
+            function: builder.m.function,
+            call: builder
+                .m
+                .web3
+                .eth()
+                .call(
                     CallRequest {
                         from: builder.m.tx.from.map(|account| account.address()),
                         to: builder.m.tx.to.unwrap_or_default(),
@@ -226,17 +236,41 @@ impl<T: Transport, R: Detokenize> CallFuture<T, R> {
                         data: builder.m.tx.data,
                     },
                     builder.block,
-                ),
-                builder.m.function,
-            )
-            .compat(),
-        )
+                )
+                .compat(),
+            _result: PhantomData,
+        }
     }
+}
 
-    /// Get a pinned reference to the inner `QueryResult` web3 future taht is
-    /// actually driving the query.
-    fn inner(self: Pin<&mut Self>) -> Pin<&mut CompatQueryResult<T, R>> {
-        Pin::new(&mut self.get_mut().0)
+lazy_static! {
+    static ref ERROR_SELECTOR: [u8; 4] = hash::function_selector("Error(string)");
+}
+
+fn decode_geth_call_result<R: Detokenize>(
+    function: &Function,
+    bytes: Vec<u8>,
+) -> Result<R, ExecutionError> {
+    if bytes.is_empty() {
+        // Geth does this on `revert()` without a message and `invalid()`,
+        // just treat them all as `invalid()` as generally contracts revert
+        // with messages.
+        Err(ExecutionError::CallInvalidOpcode)
+    } else if (bytes.len() + 28) % 32 == 0 && &bytes[0..4] == &ERROR_SELECTOR[..] {
+        // check to make sure that the length is of the form `4 + n * 32`
+        // bytes and it starts with `keccak256("Error(string)")` which means
+        // it is an encoded revert message from Geth nodes.
+        let message = abi::decode(&[ParamType::String], &bytes[4..])?
+            .pop()
+            .expect("decoded single parameter will yield single token")
+            .to_string()
+            .expect("decoded string parameter will always be a string");
+
+        Err(ExecutionError::CallRevert(Some(message)))
+    } else {
+        // try and decode the result.
+        let result = R::from_tokens(function.decode_output(&bytes)?)?;
+        Ok(result)
     }
 }
 
@@ -244,9 +278,14 @@ impl<T: Transport, R: Detokenize> Future for CallFuture<T, R> {
     type Output = Result<R, ExecutionError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        self.inner()
-            .poll(cx)
-            .map(|result| result.map_err(ExecutionError::from))
+        let unpinned = self.get_mut();
+        let result = ready!(Pin::new(&mut unpinned.call).poll(cx));
+
+        Poll::Ready(
+            result
+                .map_err(ExecutionError::from)
+                .and_then(|bytes| decode_geth_call_result(&unpinned.function, bytes.0)),
+        )
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -154,12 +154,12 @@ mod tests {
     #[test]
     fn execution_error_from_ganache_revert() {
         let web3_err = ganache_rpc_error(json!({
-            "stack": "RuntimeError: VM Exception while processing transaction: revert contract reverted as requested ...",
             "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
                "error": "revert",
                "program_counter": 42,
                "return": "0x",
             },
+            "stack": "RuntimeError: VM Exception while processing transaction: revert ...",
             "name": "RuntimeError",
         }));
         let err = ExecutionError::from(web3_err);
@@ -177,13 +177,13 @@ mod tests {
     #[test]
     fn execution_error_from_ganache_invalid_opcode() {
         let web3_err = ganache_rpc_error(json!({
-            "stack": "RuntimeError: VM Exception while processing transaction: revert contract reverted as requested ...",
-            "name": "RuntimeError",
             "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
                "error": "invalid opcode",
                "program_counter": 42,
                "return": "0x",
             },
+            "stack": "RuntimeError: VM Exception while processing transaction: invalid opcode...",
+            "name": "RuntimeError",
         }));
         let err = ExecutionError::from(web3_err);
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,7 @@
 
 use crate::truffle::abi::{Error as AbiError, ErrorKind as AbiErrorKind};
 use ethsign::Error as SignError;
+use jsonrpc_core::Error as JsonrpcError;
 use std::num::ParseIntError;
 use thiserror::Error;
 use web3::contract::Error as Web3ContractError;
@@ -57,9 +58,10 @@ pub enum ExecutionError {
     #[error("web3 error: {0}")]
     Web3(Web3Error),
 
-    /// An error occured while performing a web3 contract call.
-    #[error("web3 contract error: {0}")]
-    Web3Contract(#[from] Web3ContractError),
+    /// An error occured while ABI decoding the result of a contract method
+    /// call.
+    #[error("abi decode error: {0}")]
+    AbiDecode(#[from] Web3ContractError),
 
     /// An error occured while parsing numbers received from Web3 calls.
     #[error("parse error: {0}")]
@@ -71,21 +73,135 @@ pub enum ExecutionError {
 
     /// A contract call reverted.
     #[error("contract call reverted with message: {0:?}")]
-    CallRevert(Option<String>),
+    Revert(Option<String>),
 
     /// A contract call executed an invalid opcode.
     #[error("contract call executed an invalid opcode")]
-    CallInvalidOpcode,
+    InvalidOpcode,
 }
 
 impl From<Web3Error> for ExecutionError {
     fn from(err: Web3Error) -> ExecutionError {
-        ExecutionError::Web3(err)
+        match err {
+            Web3Error::Rpc(ref err) if get_error_param(err, "error") == Some("revert") => {
+                let reason = get_error_param(err, "reason").map(|reason| reason.to_owned());
+                ExecutionError::Revert(reason)
+            }
+            Web3Error::Rpc(ref err) if get_error_param(err, "error") == Some("invalid opcode") => {
+                ExecutionError::InvalidOpcode
+            }
+            err => ExecutionError::Web3(err),
+        }
     }
 }
 
 impl From<AbiError> for ExecutionError {
     fn from(err: AbiError) -> ExecutionError {
-        ExecutionError::Web3Contract(err.into())
+        ExecutionError::AbiDecode(err.into())
+    }
+}
+
+/// Gets an error parameters from a JSON RPC error.
+///
+/// These parameters are the fields inside the transaction object (by tx hash)
+/// inside the error data object. Note that we don't need to know the fake tx
+/// hash for getting the error params as there should only be one.
+fn get_error_param<'a>(err: &'a JsonrpcError, name: &str) -> Option<&'a str> {
+    fn is_hash_str(s: &str) -> bool {
+        s.len() == 66 && s[2..].parse::<H256>().is_ok()
+    }
+
+    err.data
+        .as_ref()?
+        .as_object()?
+        .iter()
+        .filter_map(|(k, v)| if is_hash_str(k) { Some(v) } else { None })
+        .next()?
+        .get(name)?
+        .as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonrpc_core::ErrorCode;
+    use serde_json::{json, Value};
+
+    #[test]
+    fn execution_error_from_ganache_revert_with_message() {
+        let web3_err = ganache_rpc_error(json!({
+            "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
+               "error": "revert",
+               "program_counter": 42,
+               "return": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000076d65737361676500000000000000000000000000000000000000000000000000",
+               "reason": "message",
+            },
+            "stack": "RuntimeError: VM Exception while processing transaction: revert contract reverted as requested ...",
+            "name": "RuntimeError",
+        }));
+        let err = ExecutionError::from(web3_err);
+
+        assert!(
+            match err {
+                ExecutionError::Revert(Some(ref reason)) if reason == "message" => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn execution_error_from_ganache_revert() {
+        let web3_err = ganache_rpc_error(json!({
+            "stack": "RuntimeError: VM Exception while processing transaction: revert contract reverted as requested ...",
+            "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
+               "error": "revert",
+               "program_counter": 42,
+               "return": "0x",
+            },
+            "name": "RuntimeError",
+        }));
+        let err = ExecutionError::from(web3_err);
+
+        assert!(
+            match err {
+                ExecutionError::Revert(None) => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn execution_error_from_ganache_invalid_opcode() {
+        let web3_err = ganache_rpc_error(json!({
+            "stack": "RuntimeError: VM Exception while processing transaction: revert contract reverted as requested ...",
+            "name": "RuntimeError",
+            "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
+               "error": "invalid opcode",
+               "program_counter": 42,
+               "return": "0x",
+            },
+        }));
+        let err = ExecutionError::from(web3_err);
+
+        assert!(
+            match err {
+                ExecutionError::InvalidOpcode => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+
+    fn ganache_rpc_error(data: Value) -> Web3Error {
+        Web3Error::Rpc(JsonrpcError {
+            code: ErrorCode::from(-32000),
+            message: "error".to_owned(),
+            data: Some(data),
+        })
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,7 +55,7 @@ impl From<AbiErrorKind> for DeployError {
 pub enum ExecutionError {
     /// An error occured while performing a web3 call.
     #[error("web3 error: {0}")]
-    Web3(#[from] Web3Error),
+    Web3(Web3Error),
 
     /// An error occured while performing a web3 contract call.
     #[error("web3 contract error: {0}")]
@@ -68,4 +68,24 @@ pub enum ExecutionError {
     /// An error occured while signing a transaction offline.
     #[error("offline sign error: {0}")]
     Sign(#[from] SignError),
+
+    /// A contract call reverted.
+    #[error("contract call reverted with message: {0:?}")]
+    CallRevert(Option<String>),
+
+    /// A contract call executed an invalid opcode.
+    #[error("contract call executed an invalid opcode")]
+    CallInvalidOpcode,
+}
+
+impl From<Web3Error> for ExecutionError {
+    fn from(err: Web3Error) -> ExecutionError {
+        ExecutionError::Web3(err)
+    }
+}
+
+impl From<AbiError> for ExecutionError {
+    fn from(err: AbiError) -> ExecutionError {
+        ExecutionError::Web3Contract(err.into())
+    }
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -6,7 +6,6 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use web3::api::Web3;
 use web3::confirm::SendTransactionWithConfirmation;
-use web3::contract::QueryResult;
 use web3::helpers::CallFuture;
 use web3::Transport;
 
@@ -70,9 +69,6 @@ impl<T: Transport> Unpin for Web3Unpin<T> {}
 
 /// Type alias for Compat01As03<CallFuture<...>> since it is used a lot.
 pub type CompatCallFuture<T, R> = Compat01As03<CallFuture<R, <T as Transport>::Out>>;
-
-/// Type alias for Compat01As03<QueryResult<...>>.
-pub type CompatQueryResult<T, R> = Compat01As03<QueryResult<R, <T as Transport>::Out>>;
 
 /// Type alias for Compat01As03<SendTransactionWithConfirmation<...>>.
 pub type CompatSendTxWithConfirmation<T> = Compat01As03<SendTransactionWithConfirmation<T>>;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,60 @@
+//! Keccak256 hash utilities.
+
+use tiny_keccak::{Hasher, Keccak};
+
+/// Perform a Keccak256 hash of data and return its 32-byte result.
+pub fn keccak256<B>(data: B) -> [u8; 32]
+where
+    B: AsRef<[u8]>,
+{
+    let mut output = [0u8; 32];
+    let mut hasher = Keccak::v256();
+    hasher.update(data.as_ref());
+    hasher.finalize(&mut output);
+    output
+}
+
+/// Calculate the function selector as per the contract ABI specification. This
+/// is definied as the first 4 bytes of the Keccak256 hash of the function
+/// signature.
+pub fn function_selector<S>(signature: S) -> [u8; 4]
+where
+    S: AsRef<str>,
+{
+    let hash = keccak256(signature.as_ref());
+    let mut selector = [0u8; 4];
+    selector.copy_from_slice(&hash[0..4]);
+    selector
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+
+    #[test]
+    fn simple_keccak_hash() {
+        // test vector retrieved from
+        // https://web3js.readthedocs.io/en/v1.2.4/web3-utils.html#sha3
+        assert_eq!(
+            keccak256([0xea]),
+            hash!("0x2f20677459120677484f7104c76deb6846a2c071f9b3152c103bb12cd54d1a4a")
+                .to_fixed_bytes(),
+        );
+    }
+
+    #[test]
+    fn simple_function_signature() {
+        // test vector retrieved from
+        // https://web3js.readthedocs.io/en/v1.2.4/web3-eth-abi.html#encodefunctionsignature
+        assert_eq!(
+            function_selector("myMethod(uint256,string)"),
+            [0x24, 0xee, 0x00, 0x97],
+        );
+    }
+
+    #[test]
+    fn revert_function_signature() {
+        assert_eq!(function_selector("Error(string)"), [0x08, 0xc3, 0x79, 0xa0]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@
 pub mod contract;
 pub mod errors;
 mod future;
+mod hash;
 pub mod sign;
 pub mod transaction;
 pub mod transport;


### PR DESCRIPTION
This adds support for decoding revert message from Geth nodes from the `eth_call` result and decoding revert messages from the RPC error on Ganache nodes.

Closes #92 

### Test Plan

CI with new unit tests.