### PR TITLE
Better Method Errors

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -14,7 +14,10 @@ use web3::types::{Address, Bytes};
 use web3::Transport;
 
 pub use self::deploy::{Deploy, DeployBuilder, DeployFuture, DeployedFuture};
-pub use self::method::{CallFuture, MethodBuilder, MethodDefaults, ViewMethodBuilder};
+pub use self::method::{
+    CallFuture, MethodBuilder, MethodDefaults, MethodFuture, MethodSendAndConfirmFuture,
+    MethodSendFuture, ViewMethodBuilder,
+};
 
 /// Represents a contract instance at an address. Provides methods for
 /// contract interaction.


### PR DESCRIPTION
Method futures now error with a new `MethodError` type that include the function signature in the error description. This makes debugging easier for method calls as distinguishing between different method calls is now easier.

Closes #97 

### Test Plan

New unit test for message signature formatting.