### PR TITLE
Confirmations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ethcontract-common = { version = "0.2.0", path = "./common" }
 ethcontract-derive = { version = "0.2.0", path = "./derive" }
 ethsign = "0.7"
 futures = { version = "0.3", features = ["compat"] }
+futures-timer = "2.0"
 jsonrpc-core = "11.0"
 lazy_static = "1.4"
 rlp = "0.4"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -24,7 +24,6 @@ async fn run() {
 
     let instance = RustCoin::builder(&web3)
         .gas(4_712_388.into())
-        .confirmations(0)
         .deploy()
         .await
         .expect("deployment failed");

--- a/examples/generate/src/main.rs
+++ b/examples/generate/src/main.rs
@@ -14,7 +14,6 @@ async fn run() {
 
     let instance = RustCoin::builder(&web3)
         .gas(4_712_388.into())
-        .confirmations(0)
         .deploy()
         .await
         .expect("deployment failed");

--- a/examples/linked.rs
+++ b/examples/linked.rs
@@ -15,13 +15,11 @@ async fn run() {
 
     let library = SimpleLibrary::builder(&web3)
         .gas(4_712_388.into())
-        .confirmations(0)
         .deploy()
         .await
         .expect("library deployment failure");
     let instance = LinkedContract::builder(&web3, library.address(), 1337.into())
         .gas(4_712_388.into())
-        .confirmations(0)
         .deploy()
         .await
         .expect("contract deployment failure");

--- a/examples/rinkeby.rs
+++ b/examples/rinkeby.rs
@@ -2,7 +2,6 @@ use ethcontract::web3::api::Web3;
 use ethcontract::web3::transports::WebSocket;
 use ethcontract::{Account, SecretKey, H256};
 use std::env;
-use std::time::Duration;
 
 ethcontract::contract!("examples/truffle/build/contracts/DeployedContract.json");
 
@@ -46,7 +45,8 @@ async fn run() {
     println!("  incrementing (this may take a while)...");
     instance
         .increment()
-        .send_and_confirm(Duration::new(5, 0), 1)
+        .confirmations(1) // wait for 1 block confirmation
+        .send()
         .await
         .expect("increment failed");
     println!(

--- a/examples/rinkeby.rs
+++ b/examples/rinkeby.rs
@@ -23,7 +23,9 @@ async fn run() {
         format!("wss://rinkeby.infura.io/ws/v3/{}", project_id)
     };
 
-    // use a WebSocket transport to support confirmations
+    // NOTE: Use a WebSocket transport for `eth_newBlockFilter` support on
+    //   Infura, filters are disabled over HTTPS. Filters are needed for
+    //   confirmation support.
     let (eloop, ws) = WebSocket::new(&infura_url).expect("transport failed");
     eloop.into_remote();
     let web3 = Web3::new(ws);

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -15,8 +15,7 @@ use web3::Transport;
 
 pub use self::deploy::{Deploy, DeployBuilder, DeployFuture, DeployedFuture};
 pub use self::method::{
-    CallFuture, MethodBuilder, MethodDefaults, MethodFuture, MethodSendAndConfirmFuture,
-    MethodSendFuture, ViewMethodBuilder,
+    CallFuture, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture, ViewMethodBuilder,
 };
 
 /// Represents a contract instance at an address. Provides methods for

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -2,7 +2,7 @@
 //! new contracts.
 
 use crate::contract::Instance;
-use crate::errors::DeployError;
+use crate::errors::{DeployError, ExecutionError};
 use crate::future::{CompatCallFuture, Web3Unpin};
 use crate::transaction::{Account, SendFuture, TransactionBuilder, TransactionResult};
 use crate::truffle::abi::ErrorKind as AbiErrorKind;
@@ -261,7 +261,9 @@ where
         let address = match tx.contract_address {
             Some(address) => address,
             None => {
-                return Poll::Ready(Err(DeployError::Failure(tx.transaction_hash)));
+                return Poll::Ready(Err(DeployError::Tx(ExecutionError::Failure(
+                    tx.transaction_hash,
+                ))));
             }
         };
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,6 +40,11 @@ pub enum DeployError {
     #[error("error executing contract deployment transaction: {0}")]
     Tx(#[from] ExecutionError),
 
+    /// Transaction was unable to confirm and is still pending. The contract
+    /// address cannot be determined.
+    #[error("contract deployment transaction pending: {0}")]
+    Pending(H256),
+
     /// Transaction failure (e.g. out of gas).
     #[error("contract deployment transaction failed: {0}")]
     Failure(H256),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,10 +44,6 @@ pub enum DeployError {
     /// address cannot be determined.
     #[error("contract deployment transaction pending: {0}")]
     Pending(H256),
-
-    /// Transaction failure (e.g. out of gas).
-    #[error("contract deployment transaction failed: {0}")]
-    Failure(H256),
 }
 
 impl From<AbiErrorKind> for DeployError {
@@ -85,8 +81,12 @@ pub enum ExecutionError {
     InvalidOpcode,
 
     /// A contract transaction failed to confirm within the block timeout limit.
-    #[error("contract transaction timed-out")]
+    #[error("transaction timed-out")]
     ConfirmTimeout,
+
+    /// Transaction failure (e.g. out of gas or revert).
+    #[error("transaction failed: {0}")]
+    Failure(H256),
 }
 
 impl From<Web3Error> for ExecutionError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -78,6 +78,10 @@ pub enum ExecutionError {
     /// A contract call executed an invalid opcode.
     #[error("contract call executed an invalid opcode")]
     InvalidOpcode,
+
+    /// A contract transaction failed to confirm within the block timeout limit.
+    #[error("contract transaction timed-out")]
+    ConfirmTimeout,
 }
 
 impl From<Web3Error> for ExecutionError {

--- a/src/future.rs
+++ b/src/future.rs
@@ -5,7 +5,6 @@ use std::ops::Deref;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use web3::api::Web3;
-use web3::confirm::SendTransactionWithConfirmation;
 use web3::helpers::CallFuture;
 use web3::Transport;
 
@@ -69,6 +68,3 @@ impl<T: Transport> Unpin for Web3Unpin<T> {}
 
 /// Type alias for Compat01As03<CallFuture<...>> since it is used a lot.
 pub type CompatCallFuture<T, R> = Compat01As03<CallFuture<R, <T as Transport>::Out>>;
-
-/// Type alias for Compat01As03<SendTransactionWithConfirmation<...>>.
-pub type CompatSendTxWithConfirmation<T> = Compat01As03<SendTransactionWithConfirmation<T>>;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -71,7 +71,7 @@ impl Default for ResolveCondition {
 
 /// Represents the result of a sent transaction that can either be a transaction
 /// hash, in the case the transaction was not confirmed, or a full transaction
-/// receipt is the `TransactionBuilder` was configured to wait for confirmation
+/// receipt if the `TransactionBuilder` was configured to wait for confirmation
 /// blocks.
 ///
 /// Note that the result will always be a `TransactionResult::Hash` if

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,8 @@
 //! Implementation for setting up, signing, estimating gas and sending
 //! transactions on the Ethereum network.
 
+pub mod confirm;
+
 use crate::errors::ExecutionError;
 use crate::future::{CompatCallFuture, CompatSendTxWithConfirmation, MaybeReady, Web3Unpin};
 use crate::sign::TransactionData;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,8 @@
 //! Implementation for setting up, signing, estimating gas and sending
 //! transactions on the Ethereum network.
 
+pub mod confirm;
+
 use crate::errors::ExecutionError;
 use crate::future::{CompatCallFuture, CompatSendTxWithConfirmation, MaybeReady, Web3Unpin};
 use crate::sign::TransactionData;
@@ -99,6 +101,14 @@ pub struct TransactionBuilder<T: Transport> {
     /// Optional nonce to use. Defaults to the signing account's current
     /// transaction count.
     pub nonce: Option<U256>,
+    /// Optional block confirmations to wait for. Defaults to 1 confirmation
+    /// which means waiting the transaction to be mined in a single block. Use 0
+    /// to send the transaction and only place it in the mem-pool and not wait
+    /// for it to be mined.
+    pub confirmations: Option<usize>,
+    /// Options poll timeout used for waiting for block confirmations. Defaults
+    /// to 7 seconds.
+    pub poll_timeout: Option<Duration>,
 }
 
 impl<T: Transport> TransactionBuilder<T> {
@@ -113,6 +123,8 @@ impl<T: Transport> TransactionBuilder<T> {
             value: None,
             data: None,
             nonce: None,
+            confirmations: None,
+            poll_timeout: None,
         }
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -633,6 +633,7 @@ impl<T: Transport> Future for SendFuture<T> {
                 }
                 SendState::Confirming(ref mut confirm) => {
                     return Pin::new(confirm).poll(cx).map(|result| {
+                        todo!("check the receipt for reverts");
                         result
                             .map(TransactionResult::Receipt)
                             .map_err(ExecutionError::from)

--- a/src/transaction/confirm.rs
+++ b/src/transaction/confirm.rs
@@ -6,72 +6,162 @@
 //! just sent to the mem-pool but does not wait for it to get mined. Hopefully
 //! some of this can move upstream into the `web3` crate.
 
-#![allow(missing_docs)]
-
 use crate::errors::ExecutionError;
-use crate::future::CompatCallFuture;
-use futures::future::{Either, TryJoin};
+use crate::future::{CompatCallFuture, Web3Unpin};
+use futures::compat::{Compat01As03, Future01CompatExt};
+use futures::future::{self, TryJoin};
 use futures::ready;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::num::NonZeroUsize;
-use web3::api::Web3;
+use std::time::Duration;
+use web3::api::{CreateFilter, FilterStream};
+use web3::futures::stream::{Skip as Skip01, StreamFuture as StreamFuture01};
+use web3::futures::Stream as Stream01;
 use web3::types::{TransactionReceipt, H256, U256};
 use web3::Transport;
 
+/// A struct with the confirmation parameters.
+#[derive(Clone, Debug)]
+pub struct ConfirmParams {
+    /// The number of blocks to confirm the transaction with. This is the number
+    /// of blocks mined on top of the block where the transaction was mined.
+    /// This means that, for example, to just wait for the transaction to be
+    /// mined, then the number of confirmations should be 0. Positive non-zero
+    /// values indicate that extra blocks should be waited for on top of the
+    /// block where the transaction was mined.
+    pub confirmations: usize,
+    /// The polling interval. This is used as the interval between consecutive
+    /// `eth_getFilterChanges` calls to get filter updates, or the interval to
+    /// wait between confirmation checks in case filters are not supported by
+    /// the node (for example when using Infura over HTTP(S)).
+    pub poll_interval: Duration,
+    /// The maximum number of blocks to wait for a transaction to get confirmed.
+    pub block_timeout: usize,
+}
+
+/// A future that resolves once a transaction is confirmed.
 pub struct ConfirmFuture<T: Transport> {
-    web3: Web3<T>,
+    web3: Web3Unpin<T>,
     tx: H256,
-    confirmations: NonZeroUsize,
+    params: ConfirmParams,
+    starting_block_num: Option<U256>,
     state: ConfirmState<T>,
 }
 
-impl<T: Transport> ConfirmFuture<T> {
-    pub fn new(web3: Web3<T>, tx: H256, confirmations: usize) -> Either<
-}
-
-impl<T: Transport> ConfirmFuture<T> {
-    fn state_mut(self: Pin<&mut Self>) -> &mut ConfirmState<T> {
-        // NOTE: this is safe as the `state` field does not need to be pinned
-        unsafe { &mut self.get_unchecked_mut().state }
-    }
+/// The state of the confirmation future.
+enum ConfirmState<T: Transport> {
+    /// The future is in the state where it needs to setup the checking future
+    /// to see if the confirmation is complete. This is used as a intermediate
+    /// state that doesn't actually wait for anything and immediately proceeds
+    /// to the `Checking` state.
+    Check,
+    /// The future is waiting for the block number and transaction receipt to
+    /// make sure that enough blocks have passed since the transaction was
+    /// mined. Note that the transaction receipt is retrieved everytime in case
+    /// of ommered blocks.
+    Checking(CheckFuture<T>),
+    /// The future is waiting for the block filter to be created so that it can
+    /// wait for blocks to go by.
+    CreatingFilter(CompatCreateFilter<T, H256>, u64),
+    /// The future is waiting for new blocks to be mined and added to the chain
+    /// so that the transaction can be confirmed the desired number of blocks.
+    WaitingForBlocks(CompatFilterFuture<T, H256>),
+    /// The future is waiting for a poll timeout. This state happens when the
+    /// node does not support block filters for the given transport (like Infura
+    /// over HTTPS) so we need to fallback to polling.
+    WaitingForPollTimeout,
 }
 
 impl<T: Transport> Future for ConfirmFuture<T> {
-    type Output = Result<TransactionResult, ExecutionError>;
+    type Output = Result<TransactionReceipt, ExecutionError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let unpinned = Pin::into_inner(self);
         loop {
-            match self.as_mut().state_mut() {
+            unpinned.state = match &mut unpinned.state {
+                ConfirmState::Check => ConfirmState::Checking(future::try_join(
+                    unpinned.web3.eth().block_number().compat(),
+                    unpinned
+                        .web3
+                        .eth()
+                        .transaction_receipt(unpinned.tx)
+                        .compat(),
+                )),
                 ConfirmState::Checking(ref mut check) => {
                     let (block_num, tx) = match ready!(Pin::new(check).poll(cx)) {
                         Ok(result) => result,
                         Err(err) => return Poll::Ready(Err(err.into())),
                     };
-                    let tx_block_num = tx.and_then(|tx| tx.block_number).unwrap_or(block_num);
 
-                    if block_num + 1 >= tx_block_num + self.confirmations.get() {
-                        return Poll::Ready
+                    // NOTE: If the transaction hasn't been mined, then assume
+                    //   it will be picked up in the next block.
+                    let tx_block_num = tx
+                        .as_ref()
+                        .and_then(|tx| tx.block_number)
+                        .unwrap_or(block_num + 1);
+
+                    let target_block_num = tx_block_num + unpinned.params.confirmations;
+                    let remaining_confirmations = target_block_num.saturating_sub(block_num);
+
+                    if remaining_confirmations.is_zero() {
+                        // NOTE: It is safe to unwrap here since if tx is `None`
+                        //   then the `remaining_confirmations` will always be
+                        //   positive since `tx_block_num` will be a future
+                        //   block.
+                        return Poll::Ready(Ok(tx.unwrap()));
                     }
-                    todo!()
+
+                    let starting_block_num = *unpinned.starting_block_num.get_or_insert(block_num);
+                    if block_num.saturating_sub(starting_block_num)
+                        > U256::from(unpinned.params.block_timeout)
+                    {
+                        return Poll::Ready(Err(ExecutionError::ConfirmTimeout));
+                    }
+
+                    ConfirmState::CreatingFilter(
+                        unpinned.web3.eth_filter().create_blocks_filter().compat(),
+                        remaining_confirmations.as_u64(),
+                    )
                 }
-                ConfirmState::WaitingForBlocks(ref mut wait) => todo!(),
+                ConfirmState::CreatingFilter(ref mut create_filter, count) => {
+                    match ready!(Pin::new(create_filter).poll(cx)) {
+                        Ok(filter) => ConfirmState::WaitingForBlocks(
+                            filter
+                                .stream(unpinned.params.poll_interval)
+                                .skip(*count)
+                                .into_future()
+                                .compat(),
+                        ),
+                        Err(_) => {
+                            // NOTE: In the case we fail to create a filter
+                            //   (usually because the node doesn't support pub/
+                            //   sub) then fall back to polling.
+                            ConfirmState::WaitingForPollTimeout
+                        }
+                    }
+                }
+                ConfirmState::WaitingForBlocks(ref mut wait) => {
+                    match ready!(Pin::new(wait).poll(cx)) {
+                        Ok(_) => ConfirmState::Check,
+                        Err((err, _)) => return Poll::Ready(Err(err.into())),
+                    }
+                }
+                ConfirmState::WaitingForPollTimeout => todo!("polling is currently not supported"),
             }
         }
     }
 }
 
-enum ConfirmState<T: Transport> {
-    Checking(CheckFuture<T>),
-    WaitingForBlocks(WaitForBlocksFuture<T>),
-}
+/// A type alias for a joined `eth_blockNumber` and `eth_getTransactionReceipt`
+/// calls. Used when checking that the transaction has been confirmed by enough
+/// blocks.
+type CheckFuture<T> =
+    TryJoin<CompatCallFuture<T, U256>, CompatCallFuture<T, Option<TransactionReceipt>>>;
 
-type CheckFuture<T> = TryJoin<CompatCallFuture<T, U256>, CompatCallFuture<T, TransactionReceipt>>;
+/// A type alias for a future creating a `eth_newBlockFilter` filter.
+type CompatCreateFilter<T, R> = Compat01As03<CreateFilter<T, R>>;
 
-struct WaitForBlocksFuture<T>(T);
-
-pub enum TransactionResult {
-    Hash(H256),
-    Receipt(TransactionReceipt),
-}
+/// A type alias for a future that resolves once the block filter has received
+/// a certain number of blocks.
+type CompatFilterFuture<T, R> = Compat01As03<StreamFuture01<Skip01<FilterStream<T, R>>>>;

--- a/src/transaction/confirm.rs
+++ b/src/transaction/confirm.rs
@@ -1,0 +1,77 @@
+//! Transaction confirmation implementation. This is a re-implementation of
+//! `web3` confirmation future to fix issues with development nodes like Ganache
+//! where the transaction gets mined right away, so waiting for 1 confirmation
+//! would require another transaction to be sent so a new block could mine.
+//! Additionally, waiting for 0 confirmations in `web3` means that the tx is
+//! just sent to the mem-pool but does not wait for it to get mined. Hopefully
+//! some of this can move upstream into the `web3` crate.
+
+#![allow(missing_docs)]
+
+use crate::errors::ExecutionError;
+use crate::future::CompatCallFuture;
+use futures::future::{Either, TryJoin};
+use futures::ready;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::num::NonZeroUsize;
+use web3::api::Web3;
+use web3::types::{TransactionReceipt, H256, U256};
+use web3::Transport;
+
+pub struct ConfirmFuture<T: Transport> {
+    web3: Web3<T>,
+    tx: H256,
+    confirmations: NonZeroUsize,
+    state: ConfirmState<T>,
+}
+
+impl<T: Transport> ConfirmFuture<T> {
+    pub fn new(web3: Web3<T>, tx: H256, confirmations: usize) -> Either<
+}
+
+impl<T: Transport> ConfirmFuture<T> {
+    fn state_mut(self: Pin<&mut Self>) -> &mut ConfirmState<T> {
+        // NOTE: this is safe as the `state` field does not need to be pinned
+        unsafe { &mut self.get_unchecked_mut().state }
+    }
+}
+
+impl<T: Transport> Future for ConfirmFuture<T> {
+    type Output = Result<TransactionResult, ExecutionError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        loop {
+            match self.as_mut().state_mut() {
+                ConfirmState::Checking(ref mut check) => {
+                    let (block_num, tx) = match ready!(Pin::new(check).poll(cx)) {
+                        Ok(result) => result,
+                        Err(err) => return Poll::Ready(Err(err.into())),
+                    };
+                    let tx_block_num = tx.and_then(|tx| tx.block_number).unwrap_or(block_num);
+
+                    if block_num + 1 >= tx_block_num + self.confirmations.get() {
+                        return Poll::Ready
+                    }
+                    todo!()
+                }
+                ConfirmState::WaitingForBlocks(ref mut wait) => todo!(),
+            }
+        }
+    }
+}
+
+enum ConfirmState<T: Transport> {
+    Checking(CheckFuture<T>),
+    WaitingForBlocks(WaitForBlocksFuture<T>),
+}
+
+type CheckFuture<T> = TryJoin<CompatCallFuture<T, U256>, CompatCallFuture<T, TransactionReceipt>>;
+
+struct WaitForBlocksFuture<T>(T);
+
+pub enum TransactionResult {
+    Hash(H256),
+    Receipt(TransactionReceipt),
+}

--- a/src/transaction/confirm.rs
+++ b/src/transaction/confirm.rs
@@ -198,8 +198,9 @@ impl<T: Transport> Future for ConfirmFuture<T> {
                         ),
                         Err(_) => {
                             // NOTE: In the case we fail to create a filter
-                            //   (usually because the node doesn't support pub/
-                            //   sub) then fall back to polling.
+                            //   (usually because the node doesn't support
+                            //   filters like Infura over HTTPS) then fall back
+                            //   to polling.
                             ConfirmState::PollDelay(
                                 Delay::new(unpinned.params.poll_interval),
                                 *target_block_num,

--- a/src/transaction/confirm.rs
+++ b/src/transaction/confirm.rs
@@ -51,7 +51,7 @@ pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(7);
 #[cfg(test)]
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(0);
 
-/// The default poll interval to use for confirming transactions.
+/// The default block timeout to use for confirming transactions.
 pub const DEFAULT_BLOCK_TIMEOUT: usize = 25;
 
 impl ConfirmParams {

--- a/src/transaction/confirm.rs
+++ b/src/transaction/confirm.rs
@@ -1,0 +1,602 @@
+//! Transaction confirmation implementation. This is a re-implementation of
+//! `web3` confirmation future to fix issues with development nodes like Ganache
+//! where the transaction gets mined right away, so waiting for 1 confirmation
+//! would require another transaction to be sent so a new block could mine.
+//! Additionally, waiting for 0 confirmations in `web3` means that the tx is
+//! just sent to the mem-pool but does not wait for it to get mined. Hopefully
+//! some of this can move upstream into the `web3` crate.
+
+use crate::errors::ExecutionError;
+use crate::future::{CompatCallFuture, MaybeReady, Web3Unpin};
+use futures::compat::{Compat01As03, Future01CompatExt};
+use futures::future::{self, TryJoin};
+use futures::ready;
+use futures_timer::Delay;
+use std::fmt::{self, Debug, Formatter};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use web3::api::{CreateFilter, FilterStream, Web3};
+use web3::futures::stream::{Skip as Skip01, StreamFuture as StreamFuture01};
+use web3::futures::Stream as Stream01;
+use web3::types::{TransactionReceipt, H256, U256};
+use web3::Transport;
+
+/// A struct with the confirmation parameters.
+#[derive(Clone, Debug)]
+pub struct ConfirmParams {
+    /// The number of blocks to confirm the transaction with. This is the number
+    /// of blocks mined on top of the block where the transaction was mined.
+    /// This means that, for example, to just wait for the transaction to be
+    /// mined, then the number of confirmations should be 0. Positive non-zero
+    /// values indicate that extra blocks should be waited for on top of the
+    /// block where the transaction was mined.
+    pub confirmations: usize,
+    /// The polling interval. This is used as the interval between consecutive
+    /// `eth_getFilterChanges` calls to get filter updates, or the interval to
+    /// wait between confirmation checks in case filters are not supported by
+    /// the node (for example when using Infura over HTTP(S)).
+    pub poll_interval: Duration,
+    /// The maximum number of blocks to wait for a transaction to get confirmed.
+    pub block_timeout: usize,
+}
+
+/// The default poll interval to use for confirming transactions.
+///
+/// Note that this is currently 7 seconds as this is what was chosen in `web3`
+/// crate.
+#[cfg(not(test))]
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(7);
+#[cfg(test)]
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(0);
+
+/// The default poll interval to use for confirming transactions.
+pub const DEFAULT_BLOCK_TIMEOUT: usize = 25;
+
+impl ConfirmParams {
+    /// Create new confirmation parameters for just confirming that the
+    /// transaction was mined but not confirmed with any extra blocks.
+    pub fn mined() -> Self {
+        ConfirmParams::with_confirmations(0)
+    }
+
+    /// Create new confirmation parameters from the specified number of extra
+    /// blocks to wait for with the default poll interval.
+    pub fn with_confirmations(count: usize) -> Self {
+        ConfirmParams {
+            confirmations: count,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            block_timeout: DEFAULT_BLOCK_TIMEOUT,
+        }
+    }
+}
+
+impl Default for ConfirmParams {
+    fn default() -> Self {
+        ConfirmParams::mined()
+    }
+}
+
+/// A future that resolves once a transaction is confirmed.
+#[derive(Debug)]
+pub struct ConfirmFuture<T: Transport> {
+    web3: Web3Unpin<T>,
+    /// The transaction hash that is being confirmed.
+    tx: H256,
+    /// The confirmation parameters (like number of confirming blocks to wait
+    /// for and polling interval).
+    params: ConfirmParams,
+    /// The current block number when confirmation started. This is used for
+    /// timeouts.
+    starting_block_num: Option<U256>,
+    /// The current state of the confirmation.
+    state: ConfirmState<T>,
+}
+
+/// The state of the confirmation future.
+enum ConfirmState<T: Transport> {
+    /// The future is in the state where it needs to setup the checking future
+    /// to see if the confirmation is complete. This is used as a intermediate
+    /// state that doesn't actually wait for anything and immediately proceeds
+    /// to the `Checking` state.
+    Check,
+    /// The future is waiting for the block number and transaction receipt to
+    /// make sure that enough blocks have passed since the transaction was
+    /// mined. Note that the transaction receipt is retrieved everytime in case
+    /// of ommered blocks.
+    Checking(CheckFuture<T>),
+    /// The future is waiting for the block filter to be created so that it can
+    /// wait for blocks to go by.
+    CreatingFilter(CompatCreateFilter<T, H256>, U256, u64),
+    /// The future is waiting for new blocks to be mined and added to the chain
+    /// so that the transaction can be confirmed the desired number of blocks.
+    WaitingForBlocks(CompatFilterFuture<T, H256>),
+    /// The future is waiting for a poll timeout. This state happens when the
+    /// node does not support block filters for the given transport (like Infura
+    /// over HTTPS) so we need to fallback to polling.
+    PollDelay(Delay, U256),
+    /// The future is checking that the current block number has reached a
+    /// certain target after waiting the poll delay.
+    PollCheckingBlockNumber(CompatCallFuture<T, U256>, U256),
+}
+
+impl<T: Transport> ConfirmFuture<T> {
+    /// Create a new `ConfirmFuture` with a `web3` provider for the specified
+    /// transaction hash and with the specified parameters.
+    pub fn new(web3: &Web3<T>, tx: H256, params: ConfirmParams) -> Self {
+        ConfirmFuture {
+            web3: web3.clone().into(),
+            tx,
+            params,
+            starting_block_num: None,
+            state: ConfirmState::Check,
+        }
+    }
+}
+
+impl<T: Transport> Future for ConfirmFuture<T> {
+    type Output = Result<TransactionReceipt, ExecutionError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let unpinned = self.get_mut();
+        loop {
+            unpinned.state = match &mut unpinned.state {
+                ConfirmState::Check => ConfirmState::Checking(future::try_join(
+                    MaybeReady::future(unpinned.web3.eth().block_number().compat()),
+                    unpinned
+                        .web3
+                        .eth()
+                        .transaction_receipt(unpinned.tx)
+                        .compat(),
+                )),
+                ConfirmState::Checking(ref mut check) => {
+                    let (block_num, tx) = match ready!(Pin::new(check).poll(cx)) {
+                        Ok(result) => result,
+                        Err(err) => return Poll::Ready(Err(err.into())),
+                    };
+
+                    // NOTE: If the transaction hasn't been mined, then assume
+                    //   it will be picked up in the next block.
+                    let tx_block_num = tx
+                        .as_ref()
+                        .and_then(|tx| tx.block_number)
+                        .unwrap_or(block_num + 1);
+
+                    let target_block_num = tx_block_num + unpinned.params.confirmations;
+                    let remaining_confirmations = target_block_num.saturating_sub(block_num);
+
+                    if remaining_confirmations.is_zero() {
+                        // NOTE: It is safe to unwrap here since if tx is `None`
+                        //   then the `remaining_confirmations` will always be
+                        //   positive since `tx_block_num` will be a future
+                        //   block.
+                        return Poll::Ready(Ok(tx.unwrap()));
+                    }
+
+                    let starting_block_num = *unpinned.starting_block_num.get_or_insert(block_num);
+                    if block_num.saturating_sub(starting_block_num)
+                        > U256::from(unpinned.params.block_timeout)
+                    {
+                        return Poll::Ready(Err(ExecutionError::ConfirmTimeout));
+                    }
+
+                    ConfirmState::CreatingFilter(
+                        unpinned.web3.eth_filter().create_blocks_filter().compat(),
+                        target_block_num,
+                        remaining_confirmations.as_u64(),
+                    )
+                }
+                ConfirmState::CreatingFilter(ref mut create_filter, target_block_num, count) => {
+                    match ready!(Pin::new(create_filter).poll(cx)) {
+                        Ok(filter) => ConfirmState::WaitingForBlocks(
+                            filter
+                                .stream(unpinned.params.poll_interval)
+                                .skip(*count - 1)
+                                .into_future()
+                                .compat(),
+                        ),
+                        Err(_) => {
+                            // NOTE: In the case we fail to create a filter
+                            //   (usually because the node doesn't support pub/
+                            //   sub) then fall back to polling.
+                            ConfirmState::PollDelay(
+                                Delay::new(unpinned.params.poll_interval),
+                                *target_block_num,
+                            )
+                        }
+                    }
+                }
+                ConfirmState::WaitingForBlocks(ref mut wait) => {
+                    match ready!(Pin::new(wait).poll(cx)) {
+                        Ok(_) => ConfirmState::Check,
+                        Err((err, _)) => return Poll::Ready(Err(err.into())),
+                    }
+                }
+                ConfirmState::PollDelay(ref mut delay, target_block_num) => {
+                    ready!(Pin::new(delay).poll(cx));
+                    ConfirmState::PollCheckingBlockNumber(
+                        unpinned.web3.eth().block_number().compat(),
+                        *target_block_num,
+                    )
+                }
+                ConfirmState::PollCheckingBlockNumber(ref mut block_num, target_block_num) => {
+                    let block_num = match ready!(Pin::new(block_num).poll(cx)) {
+                        Ok(block_num) => block_num,
+                        Err(err) => return Poll::Ready(Err(err.into())),
+                    };
+
+                    if block_num == *target_block_num {
+                        ConfirmState::Checking(future::try_join(
+                            MaybeReady::ready(Ok(block_num)),
+                            unpinned
+                                .web3
+                                .eth()
+                                .transaction_receipt(unpinned.tx)
+                                .compat(),
+                        ))
+                    } else {
+                        ConfirmState::PollDelay(
+                            Delay::new(unpinned.params.poll_interval),
+                            *target_block_num,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T: Transport> Debug for ConfirmState<T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            ConfirmState::Check => f.debug_tuple("Check").finish(),
+            ConfirmState::Checking(_) => f.debug_tuple("Checking").finish(),
+            ConfirmState::CreatingFilter(_, t, c) => {
+                f.debug_tuple("CreatingFilter").field(t).field(c).finish()
+            }
+            ConfirmState::WaitingForBlocks(_) => f.debug_tuple("WaitingForBlocks").finish(),
+            ConfirmState::PollDelay(d, t) => f.debug_tuple("PollDelay").field(d).field(t).finish(),
+            ConfirmState::PollCheckingBlockNumber(_, t) => {
+                f.debug_tuple("PollCheckingBlockNumber").field(t).finish()
+            }
+        }
+    }
+}
+
+/// A type alias for a joined `eth_blockNumber` and `eth_getTransactionReceipt`
+/// calls. Used when checking that the transaction has been confirmed by enough
+/// blocks.
+type CheckFuture<T> =
+    TryJoin<MaybeReady<CompatCallFuture<T, U256>>, CompatCallFuture<T, Option<TransactionReceipt>>>;
+
+/// A type alias for a future creating a `eth_newBlockFilter` filter.
+type CompatCreateFilter<T, R> = Compat01As03<CreateFilter<T, R>>;
+
+/// A type alias for a future that resolves once the block filter has received
+/// a certain number of blocks.
+type CompatFilterFuture<T, R> = Compat01As03<StreamFuture01<Skip01<FilterStream<T, R>>>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+    use serde_json::Value;
+    use web3::types::H2048;
+
+    fn generate_tx_receipt<U: Into<U256>>(hash: H256, block_num: U) -> Value {
+        json!({
+            "transactionHash": hash,
+            "transactionIndex": "0x1",
+            "blockNumber": block_num.into(),
+            "blockHash": H256::zero(),
+            "cumulativeGasUsed": "0x1337",
+            "gasUsed": "0x1337",
+            "logsBloom": H2048::zero(),
+            "logs": [],
+        })
+    }
+
+    #[test]
+    fn confirm_mined_transaction() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let hash = H256::repeat_byte(0xff);
+
+        // transaction pending
+        transport.add_response(json!("0x1"));
+        transport.add_response(json!(null));
+        // filter created
+        transport.add_response(json!("0xf0"));
+        // polled block filter for 1 new block
+        transport.add_response(json!([]));
+        transport.add_response(json!([]));
+        transport.add_response(json!([H256::repeat_byte(2)]));
+        // check transaction was mined
+        transport.add_response(json!("0x2"));
+        transport.add_response(generate_tx_receipt(hash, 2));
+
+        let confirm = ConfirmFuture::new(&web3, hash, ConfirmParams::mined())
+            .wait()
+            .expect("transaction confirmation failed");
+
+        assert_eq!(confirm.transaction_hash, hash);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_no_more_requests();
+    }
+
+    #[test]
+    fn confirm_auto_mined_transaction() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let hash = H256::repeat_byte(0xff);
+
+        transport.add_response(json!("0x1"));
+        transport.add_response(generate_tx_receipt(hash, 1));
+
+        let confirm = ConfirmFuture::new(&web3, hash, ConfirmParams::mined())
+            .wait()
+            .expect("transaction confirmation failed");
+
+        assert_eq!(confirm.transaction_hash, hash);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_no_more_requests();
+    }
+
+    #[test]
+    fn confirmations_with_filter() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let hash = H256::repeat_byte(0xff);
+
+        // transaction pending
+        transport.add_response(json!("0x1"));
+        transport.add_response(json!(null));
+        // filter created
+        transport.add_response(json!("0xf0"));
+        // polled block filter 4 times
+        transport.add_response(json!([H256::repeat_byte(2), H256::repeat_byte(3)]));
+        transport.add_response(json!([]));
+        transport.add_response(json!([H256::repeat_byte(4)]));
+        transport.add_response(json!([H256::repeat_byte(5)]));
+        // check confirmation again - transaction mined on block 3 instead of 2
+        transport.add_response(json!("0x5"));
+        transport.add_response(generate_tx_receipt(hash, 3));
+        // needs to wait 1 more block - creating filter again and polling
+        transport.add_response(json!("0xf1"));
+        transport.add_response(json!([H256::repeat_byte(6)]));
+        // check confirmation one last time
+        transport.add_response(json!("0x6"));
+        transport.add_response(generate_tx_receipt(hash, 3));
+
+        let confirm = ConfirmFuture::new(&web3, hash, ConfirmParams::with_confirmations(3))
+            .wait()
+            .expect("transaction confirmation failed");
+
+        assert_eq!(confirm.transaction_hash, hash);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf1")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_no_more_requests();
+    }
+
+    #[test]
+    fn confirmations_with_polling() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let hash = H256::repeat_byte(0xff);
+
+        // transaction pending
+        transport.add_response(json!("0x1"));
+        transport.add_response(json!(null));
+        // filter created not supported
+        transport.add_response(json!({ "error": "eth_newBlockFilter not supported" }));
+        // poll block number until new block is found
+        transport.add_response(json!("0x1"));
+        transport.add_response(json!("0x1"));
+        transport.add_response(json!("0x2"));
+        transport.add_response(json!("0x2"));
+        transport.add_response(json!("0x2"));
+        transport.add_response(json!("0x3"));
+        // check transaction was mined - note that the block number doesn't get
+        // re-queried and is re-used from the polling loop.
+        transport.add_response(generate_tx_receipt(hash, 2));
+
+        let confirm = ConfirmFuture::new(&web3, hash, ConfirmParams::with_confirmations(1))
+            .wait()
+            .expect("transaction confirmation failed");
+
+        assert_eq!(confirm.transaction_hash, hash);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_no_more_requests();
+    }
+
+    #[test]
+    fn confirmations_with_reorg_tx_receipt() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let hash = H256::repeat_byte(0xff);
+
+        // transaction pending
+        transport.add_response(json!("0x1"));
+        transport.add_response(json!(null));
+        // filter created - poll for 2 blocks
+        transport.add_response(json!("0xf0"));
+        transport.add_response(json!([H256::repeat_byte(2)]));
+        transport.add_response(json!([H256::repeat_byte(3)]));
+        // check confirmation again - transaction mined on block 3
+        transport.add_response(json!("0x3"));
+        transport.add_response(generate_tx_receipt(hash, 3));
+        // needs to wait 1 more block - creating filter again and polling
+        transport.add_response(json!("0xf1"));
+        transport.add_response(json!([H256::repeat_byte(4)]));
+        // check confirmation - reorg happened, tx mined on block 4!
+        transport.add_response(json!("0x4"));
+        transport.add_response(generate_tx_receipt(hash, 4));
+        // wait for another block
+        transport.add_response(json!("0xf2"));
+        transport.add_response(json!([H256::repeat_byte(5)]));
+        // check confirmation - and we are satisfied.
+        transport.add_response(json!("0x5"));
+        transport.add_response(generate_tx_receipt(hash, 4));
+
+        let confirm = ConfirmFuture::new(&web3, hash, ConfirmParams::with_confirmations(1))
+            .wait()
+            .expect("transaction confirmation failed");
+
+        assert_eq!(confirm.transaction_hash, hash);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf1")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf2")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_no_more_requests();
+    }
+
+    #[test]
+    fn confirmations_with_reorg_blocks() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let hash = H256::repeat_byte(0xff);
+
+        // transaction pending
+        transport.add_response(json!("0x1"));
+        transport.add_response(json!(null));
+        // filter created - poll for 2 blocks
+        transport.add_response(json!("0xf0"));
+        transport.add_response(json!([H256::repeat_byte(2)]));
+        transport.add_response(json!([H256::repeat_byte(3)]));
+        transport.add_response(json!([H256::repeat_byte(4)]));
+        // check confirmation again - transaction mined on block 3
+        transport.add_response(json!("0x4"));
+        transport.add_response(generate_tx_receipt(hash, 3));
+        // needs to wait 1 more block - creating filter again and polling
+        transport.add_response(json!("0xf1"));
+        transport.add_response(json!([H256::repeat_byte(5)]));
+        // check confirmation - reorg happened and block 4 was replaced
+        transport.add_response(json!("0x4"));
+        transport.add_response(generate_tx_receipt(hash, 3));
+        // wait for another block
+        transport.add_response(json!("0xf2"));
+        transport.add_response(json!([H256::repeat_byte(6)]));
+        // check confirmation - and we are satisfied.
+        transport.add_response(json!("0x5"));
+        transport.add_response(generate_tx_receipt(hash, 3));
+
+        let confirm = ConfirmFuture::new(&web3, hash, ConfirmParams::with_confirmations(2))
+            .wait()
+            .expect("transaction confirmation failed");
+
+        assert_eq!(confirm.transaction_hash, hash);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf1")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_request("eth_newBlockFilter", &[]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf2")]);
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_no_more_requests();
+    }
+
+    #[test]
+    fn confirmation_timeout() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let hash = H256::repeat_byte(0xff);
+        let params = ConfirmParams::mined();
+        let timeout = params.block_timeout + 1;
+
+        // wait for the transaction a total of block timeout + 1 times
+        for i in 0..timeout {
+            let block_num = format!("0x{:x}", i + 1);
+            let filter_id = format!("0xf{:x}", i);
+
+            // transaction is pending
+            transport.add_response(json!(block_num));
+            transport.add_response(json!(null));
+            transport.add_response(json!(filter_id));
+            transport.add_response(json!([H256::repeat_byte(2)]));
+        }
+
+        let block_num = format!("0x{:x}", timeout + 1);
+        transport.add_response(json!(block_num));
+        transport.add_response(json!(null));
+
+        let confirm = ConfirmFuture::new(&web3, hash, params).wait();
+
+        assert!(
+            match &confirm {
+                Err(ExecutionError::ConfirmTimeout) => true,
+                _ => false,
+            },
+            "expected confirmation to time out but got {:?}",
+            confirm
+        );
+
+        for i in 0..timeout {
+            let filter_id = format!("0xf{:x}", i);
+
+            transport.assert_request("eth_blockNumber", &[]);
+            transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+            transport.assert_request("eth_newBlockFilter", &[]);
+            transport.assert_request("eth_getFilterChanges", &[json!(filter_id)]);
+        }
+
+        transport.assert_request("eth_blockNumber", &[]);
+        transport.assert_request("eth_getTransactionReceipt", &[json!(hash)]);
+        transport.assert_no_more_requests();
+    }
+}

--- a/src/transaction/confirm.rs
+++ b/src/transaction/confirm.rs
@@ -121,7 +121,7 @@ impl<T: Transport> Future for ConfirmFuture<T> {
     type Output = Result<TransactionReceipt, ExecutionError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        let unpinned = Pin::into_inner(self);
+        let unpinned = self.get_mut();
         loop {
             unpinned.state = match &mut unpinned.state {
                 ConfirmState::Check => ConfirmState::Checking(future::try_join(


### PR DESCRIPTION
This PR unifies the confirmation API between all transaction (deployment and method calls) and eliminates the `send_and_confirm` method as now confirmation parameters are part of the transaction builder.

Note that this also addresses some issues with confirmation. A new case was created to upstream some of these issues to `web3` crate here: #104. Details of the issues with the current confirmation implementation are in the aforementioned issue.

This closes #95 

### Test Plan

New unit tests for the confirmation implementation and add waiting for confirmation with Ganache example. (Note that Rinkeby example currently waits for confirmation already). 