### PR TITLE
[Easy] Use `Self` instead of type name

### DIFF
--- a/common/src/truffle.rs
+++ b/common/src/truffle.rs
@@ -32,7 +32,7 @@ pub struct Artifact {
 
 impl Artifact {
     /// Creates an empty artifact instance.
-    pub fn empty() -> Artifact {
+    pub fn empty() -> Self {
         Artifact {
             contract_name: String::new(),
             abi: Abi {
@@ -49,7 +49,7 @@ impl Artifact {
     }
 
     /// Parse a truffle artifact from JSON.
-    pub fn from_json<S>(json: S) -> Result<Artifact, ArtifactError>
+    pub fn from_json<S>(json: S) -> Result<Self, ArtifactError>
     where
         S: AsRef<str>,
     {
@@ -58,7 +58,7 @@ impl Artifact {
     }
 
     /// Loads a truffle artifact from disk.
-    pub fn load<P>(path: P) -> Result<Artifact, ArtifactError>
+    pub fn load<P>(path: P) -> Result<Self, ArtifactError>
     where
         P: AsRef<Path>,
     {

--- a/common/src/truffle/bytecode.rs
+++ b/common/src/truffle/bytecode.rs
@@ -16,7 +16,7 @@ pub struct Bytecode(String);
 
 impl Bytecode {
     /// Read hex bytecode representation from a string slice.
-    pub fn from_hex_str<S>(s: S) -> Result<Bytecode, BytecodeError>
+    pub fn from_hex_str<S>(s: S) -> Result<Self, BytecodeError>
     where
         S: AsRef<str>,
     {

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -27,7 +27,7 @@ struct Context {
 }
 
 impl Context {
-    fn from_args(args: &Args) -> Result<Context> {
+    fn from_args(args: &Args) -> Result<Self> {
         let artifact_path = {
             let full_path = fs::canonicalize(&args.artifact_path)?;
             Literal::string(&full_path.to_string_lossy())

--- a/generate/src/lib.rs
+++ b/generate/src/lib.rs
@@ -25,7 +25,7 @@ pub(crate) struct Args {
 impl Args {
     /// Creates a new builder given the path to a contract's truffle artifact
     /// JSON file.
-    pub fn new<P>(artifact_path: P) -> Args
+    pub fn new<P>(artifact_path: P) -> Self
     where
         P: AsRef<Path>,
     {
@@ -46,7 +46,7 @@ pub struct Builder {
 impl Builder {
     /// Creates a new builder given the path to a contract's truffle artifact
     /// JSON file.
-    pub fn new<P>(artifact_path: P) -> Builder
+    pub fn new<P>(artifact_path: P) -> Self
     where
         P: AsRef<Path>,
     {
@@ -57,7 +57,7 @@ impl Builder {
 
     /// Sets the crate name for the runtime crate. This setting is usually only
     /// needed if the crate was renamed in the Cargo manifest.
-    pub fn with_runtime_crate_name<S>(mut self, name: S) -> Builder
+    pub fn with_runtime_crate_name<S>(mut self, name: S) -> Self
     where
         S: AsRef<str>,
     {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -35,7 +35,7 @@ impl<T: Transport> Instance<T> {
     ///
     /// Note that this does not verify that a contract with a matchin `Abi` is
     /// actually deployed at the given address.
-    pub fn at(web3: Web3<T>, abi: Abi, address: Address) -> Instance<T> {
+    pub fn at(web3: Web3<T>, abi: Abi, address: Address) -> Self {
         Instance {
             web3,
             abi,
@@ -49,7 +49,7 @@ impl<T: Transport> Instance<T> {
     ///
     /// Note that this does not verify that a contract with a matchin `Abi` is
     /// actually deployed at the given address.
-    pub fn deployed(web3: Web3<T>, artifact: Artifact) -> DeployedFuture<T, Instance<T>> {
+    pub fn deployed(web3: Web3<T>, artifact: Artifact) -> DeployedFuture<T, Self> {
         DeployedFuture::from_args(web3, artifact)
     }
 
@@ -60,7 +60,7 @@ impl<T: Transport> Instance<T> {
         web3: Web3<T>,
         artifact: Artifact,
         params: P,
-    ) -> Result<DeployBuilder<T, Instance<T>>, DeployError>
+    ) -> Result<DeployBuilder<T, Self>, DeployError>
     where
         P: Tokenize,
     {
@@ -74,7 +74,7 @@ impl<T: Transport> Instance<T> {
         artifact: Artifact,
         params: P,
         libraries: I,
-    ) -> Result<DeployBuilder<T, Instance<T>>, DeployError>
+    ) -> Result<DeployBuilder<T, Self>, DeployError>
     where
         P: Tokenize,
         I: Iterator<Item = (&'a str, Address)>,

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -53,7 +53,7 @@ where
 {
     /// Construct a new future that resolves when a deployed contract is located
     /// from a `web3` provider and artifact data.
-    pub fn from_args(web3: Web3<T>, artifact: Artifact) -> DeployedFuture<T, D> {
+    pub fn from_args(web3: Web3<T>, artifact: Artifact) -> Self {
         let net = web3.net();
         DeployedFuture {
             args: Some((web3.into(), artifact)),
@@ -125,11 +125,7 @@ where
 {
     /// Create a new deploy builder from a `web3` provider, artifact data and
     /// deployment (constructor) parameters.
-    pub fn new<P>(
-        web3: Web3<T>,
-        artifact: Artifact,
-        params: P,
-    ) -> Result<DeployBuilder<T, D>, DeployError>
+    pub fn new<P>(web3: Web3<T>, artifact: Artifact, params: P) -> Result<Self, DeployError>
     where
         P: Tokenize,
     {
@@ -159,35 +155,35 @@ where
 
     /// Specify the signing method to use for the transaction, if not specified
     /// the the transaction will be locally signed with the default user.
-    pub fn from(mut self, value: Account) -> DeployBuilder<T, D> {
+    pub fn from(mut self, value: Account) -> Self {
         self.tx = self.tx.from(value);
         self
     }
 
     /// Secify amount of gas to use, if not specified then a gas estimate will
     /// be used.
-    pub fn gas(mut self, value: U256) -> DeployBuilder<T, D> {
+    pub fn gas(mut self, value: U256) -> Self {
         self.tx = self.tx.gas(value);
         self
     }
 
     /// Specify the gas price to use, if not specified then the estimated gas
     /// price will be used.
-    pub fn gas_price(mut self, value: U256) -> DeployBuilder<T, D> {
+    pub fn gas_price(mut self, value: U256) -> Self {
         self.tx = self.tx.gas_price(value);
         self
     }
 
     /// Specify what how much ETH to transfer with the transaction, if not
     /// specified then no ETH will be sent.
-    pub fn value(mut self, value: U256) -> DeployBuilder<T, D> {
+    pub fn value(mut self, value: U256) -> Self {
         self.tx = self.tx.value(value);
         self
     }
 
     /// Specify the nonce for the transation, if not specified will use the
     /// current transaction count for the signing account.
-    pub fn nonce(mut self, value: U256) -> DeployBuilder<T, D> {
+    pub fn nonce(mut self, value: U256) -> Self {
         self.tx = self.tx.nonce(value);
         self
     }
@@ -195,7 +191,7 @@ where
     /// Specify the number of confirmations to wait for when confirming the
     /// transaction, if not specified will wait for the transaction to be mined
     /// without any extra confirmations.
-    pub fn confirmations(mut self, value: usize) -> DeployBuilder<T, D> {
+    pub fn confirmations(mut self, value: usize) -> Self {
         self.tx = self.tx.confirmations(value);
         self
     }
@@ -233,7 +229,7 @@ where
     D: Deploy<T>,
 {
     /// Create an instance from a `DeployBuilder`.
-    pub fn from_builder(builder: DeployBuilder<T, D>) -> DeployFuture<T, D> {
+    pub fn from_builder(builder: DeployBuilder<T, D>) -> Self {
         DeployFuture {
             args: Some((builder.web3.into(), builder.abi)),
             send: builder.tx.send(),

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -45,12 +45,7 @@ pub struct MethodBuilder<T: Transport, R> {
 
 impl<T: Transport, R> MethodBuilder<T, R> {
     /// Creates a new builder for a transaction.
-    pub fn new(
-        web3: Web3<T>,
-        function: Function,
-        address: Address,
-        data: Bytes,
-    ) -> MethodBuilder<T, R> {
+    pub fn new(web3: Web3<T>, function: Function, address: Address, data: Bytes) -> Self {
         MethodBuilder {
             web3: web3.clone(),
             function,
@@ -60,7 +55,7 @@ impl<T: Transport, R> MethodBuilder<T, R> {
     }
 
     /// Apply method defaults to this builder.
-    pub fn with_defaults(mut self, defaults: &MethodDefaults) -> MethodBuilder<T, R> {
+    pub fn with_defaults(mut self, defaults: &MethodDefaults) -> Self {
         self.tx.from = self.tx.from.or_else(|| defaults.from.clone());
         self.tx.gas = self.tx.gas.or(defaults.gas);
         self.tx.gas_price = self.tx.gas_price.or(defaults.gas_price);
@@ -69,35 +64,35 @@ impl<T: Transport, R> MethodBuilder<T, R> {
 
     /// Specify the signing method to use for the transaction, if not specified
     /// the the transaction will be locally signed with the default user.
-    pub fn from(mut self, value: Account) -> MethodBuilder<T, R> {
+    pub fn from(mut self, value: Account) -> Self {
         self.tx = self.tx.from(value);
         self
     }
 
     /// Secify amount of gas to use, if not specified then a gas estimate will
     /// be used.
-    pub fn gas(mut self, value: U256) -> MethodBuilder<T, R> {
+    pub fn gas(mut self, value: U256) -> Self {
         self.tx = self.tx.gas(value);
         self
     }
 
     /// Specify the gas price to use, if not specified then the estimated gas
     /// price will be used.
-    pub fn gas_price(mut self, value: U256) -> MethodBuilder<T, R> {
+    pub fn gas_price(mut self, value: U256) -> Self {
         self.tx = self.tx.gas_price(value);
         self
     }
 
     /// Specify what how much ETH to transfer with the transaction, if not
     /// specified then no ETH will be sent.
-    pub fn value(mut self, value: U256) -> MethodBuilder<T, R> {
+    pub fn value(mut self, value: U256) -> Self {
         self.tx = self.tx.value(value);
         self
     }
 
     /// Specify the nonce for the transation, if not specified will use the
     /// current transaction count for the signing account.
-    pub fn nonce(mut self, value: U256) -> MethodBuilder<T, R> {
+    pub fn nonce(mut self, value: U256) -> Self {
         self.tx = self.tx.nonce(value);
         self
     }
@@ -105,7 +100,7 @@ impl<T: Transport, R> MethodBuilder<T, R> {
     /// Specify the number of confirmations to wait for when confirming the
     /// transaction, if not specified will wait for the transaction to be mined
     /// without any extra confirmations.
-    pub fn confirmations(mut self, value: usize) -> MethodBuilder<T, R> {
+    pub fn confirmations(mut self, value: usize) -> Self {
         self.tx = self.tx.confirmations(value);
         self
     }
@@ -133,7 +128,7 @@ pub struct MethodFuture<F> {
 impl<F> MethodFuture<F> {
     /// Creates a new `MethodFuture` from a function ABI declaration and an
     /// inner future.
-    fn new(function: Function, inner: F) -> MethodFuture<F> {
+    fn new(function: Function, inner: F) -> Self {
         MethodFuture { function, inner }
     }
 }
@@ -184,7 +179,7 @@ pub struct ViewMethodBuilder<T: Transport, R: Detokenize> {
 
 impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
     /// Create a new `ViewMethodBuilder` by demoting a `MethodBuilder`.
-    pub fn from_method(method: MethodBuilder<T, R>) -> ViewMethodBuilder<T, R> {
+    pub fn from_method(method: MethodBuilder<T, R>) -> Self {
         ViewMethodBuilder {
             m: method,
             block: None,
@@ -192,41 +187,41 @@ impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
     }
 
     /// Apply method defaults to this builder.
-    pub fn with_defaults(mut self, defaults: &MethodDefaults) -> ViewMethodBuilder<T, R> {
+    pub fn with_defaults(mut self, defaults: &MethodDefaults) -> Self {
         self.m = self.m.with_defaults(defaults);
         self
     }
 
     /// Specify the account the transaction is being sent from.
-    pub fn from(mut self, value: Address) -> ViewMethodBuilder<T, R> {
+    pub fn from(mut self, value: Address) -> Self {
         self.m = self.m.from(Account::Local(value, None));
         self
     }
 
     /// Secify amount of gas to use, if not specified then a gas estimate will
     /// be used.
-    pub fn gas(mut self, value: U256) -> ViewMethodBuilder<T, R> {
+    pub fn gas(mut self, value: U256) -> Self {
         self.m = self.m.gas(value);
         self
     }
 
     /// Specify the gas price to use, if not specified then the estimated gas
     /// price will be used.
-    pub fn gas_price(mut self, value: U256) -> ViewMethodBuilder<T, R> {
+    pub fn gas_price(mut self, value: U256) -> Self {
         self.m = self.m.gas_price(value);
         self
     }
 
     /// Specify what how much ETH to transfer with the transaction, if not
     /// specified then no ETH will be sent.
-    pub fn value(mut self, value: U256) -> ViewMethodBuilder<T, R> {
+    pub fn value(mut self, value: U256) -> Self {
         self.m = self.m.value(value);
         self
     }
 
     /// Specify the nonce for the transation, if not specified will use the
     /// current transaction count for the signing account.
-    pub fn block(mut self, value: BlockNumber) -> ViewMethodBuilder<T, R> {
+    pub fn block(mut self, value: BlockNumber) -> Self {
         self.block = Some(value);
         self
     }
@@ -249,7 +244,7 @@ pub struct CallFuture<T: Transport, R: Detokenize> {
 
 impl<T: Transport, R: Detokenize> CallFuture<T, R> {
     /// Construct a new `CallFuture` from a `ViewMethodBuilder`.
-    fn from_builder(builder: ViewMethodBuilder<T, R>) -> CallFuture<T, R> {
+    fn from_builder(builder: ViewMethodBuilder<T, R>) -> Self {
         CallFuture {
             function: builder.m.function,
             call: builder

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,7 +47,7 @@ pub enum DeployError {
 }
 
 impl From<AbiErrorKind> for DeployError {
-    fn from(err: AbiErrorKind) -> DeployError {
+    fn from(err: AbiErrorKind) -> Self {
         DeployError::Abi(err.into())
     }
 }
@@ -90,7 +90,7 @@ pub enum ExecutionError {
 }
 
 impl From<Web3Error> for ExecutionError {
-    fn from(err: Web3Error) -> ExecutionError {
+    fn from(err: Web3Error) -> Self {
         match err {
             Web3Error::Rpc(ref err) if get_error_param(err, "error") == Some("revert") => {
                 let reason = get_error_param(err, "reason").map(|reason| reason.to_owned());
@@ -105,7 +105,7 @@ impl From<Web3Error> for ExecutionError {
 }
 
 impl From<AbiError> for ExecutionError {
-    fn from(err: AbiError) -> ExecutionError {
+    fn from(err: AbiError) -> Self {
         ExecutionError::AbiDecode(err.into())
     }
 }
@@ -145,12 +145,12 @@ pub struct MethodError {
 impl MethodError {
     /// Create a new `MethodError` from an ABI function specification and an
     /// inner `ExecutionError`.
-    pub fn new<I: Into<ExecutionError>>(function: &Function, inner: I) -> MethodError {
+    pub fn new<I: Into<ExecutionError>>(function: &Function, inner: I) -> Self {
         MethodError::from_parts(function_signature(function), inner.into())
     }
 
     /// Create a `MethodError` from its signature and inner `ExecutionError`.
-    pub fn from_parts(signature: String, inner: ExecutionError) -> MethodError {
+    pub fn from_parts(signature: String, inner: ExecutionError) -> Self {
         MethodError { signature, inner }
     }
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -19,12 +19,12 @@ impl<F: Future + Unpin> MaybeReady<F> {
     }
 
     /// Create a new `MaybeReady` with an immediate value.
-    pub fn ready(value: F::Output) -> MaybeReady<F> {
+    pub fn ready(value: F::Output) -> Self {
         MaybeReady(Either::Left(future::ready(value)))
     }
 
     /// Create a new `MaybeReady` with a deferred value.
-    pub fn future(fut: F) -> MaybeReady<F> {
+    pub fn future(fut: F) -> Self {
         MaybeReady(Either::Right(fut))
     }
 }

--- a/src/test/transport.rs
+++ b/src/test/transport.rs
@@ -43,7 +43,7 @@ impl Transport for TestTransport {
 
 impl TestTransport {
     /// Create a new test transport instance.
-    pub fn new() -> TestTransport {
+    pub fn new() -> Self {
         Default::default()
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -185,7 +185,7 @@ pub struct TransactionBuilder<T: Transport> {
 
 impl<T: Transport> TransactionBuilder<T> {
     /// Creates a new builder for a transaction.
-    pub fn new(web3: Web3<T>) -> TransactionBuilder<T> {
+    pub fn new(web3: Web3<T>) -> Self {
         TransactionBuilder {
             web3,
             from: None,
@@ -201,63 +201,63 @@ impl<T: Transport> TransactionBuilder<T> {
 
     /// Specify the signing method to use for the transaction, if not specified
     /// the the transaction will be locally signed with the default user.
-    pub fn from(mut self, value: Account) -> TransactionBuilder<T> {
+    pub fn from(mut self, value: Account) -> Self {
         self.from = Some(value);
         self
     }
 
     /// Specify the recepient of the transaction, if not specified the
     /// transaction will be sent to the 0 address (for deploying contracts).
-    pub fn to(mut self, value: Address) -> TransactionBuilder<T> {
+    pub fn to(mut self, value: Address) -> Self {
         self.to = Some(value);
         self
     }
 
     /// Secify amount of gas to use, if not specified then a gas estimate will
     /// be used.
-    pub fn gas(mut self, value: U256) -> TransactionBuilder<T> {
+    pub fn gas(mut self, value: U256) -> Self {
         self.gas = Some(value);
         self
     }
 
     /// Specify the gas price to use, if not specified then the estimated gas
     /// price will be used.
-    pub fn gas_price(mut self, value: U256) -> TransactionBuilder<T> {
+    pub fn gas_price(mut self, value: U256) -> Self {
         self.gas_price = Some(value);
         self
     }
 
     /// Specify what how much ETH to transfer with the transaction, if not
     /// specified then no ETH will be sent.
-    pub fn value(mut self, value: U256) -> TransactionBuilder<T> {
+    pub fn value(mut self, value: U256) -> Self {
         self.value = Some(value);
         self
     }
 
     /// Specify the data to use for the transaction, if not specified, then empty
     /// data will be used.
-    pub fn data(mut self, value: Bytes) -> TransactionBuilder<T> {
+    pub fn data(mut self, value: Bytes) -> Self {
         self.data = Some(value);
         self
     }
 
     /// Specify the nonce for the transation, if not specified will use the
     /// current transaction count for the signing account.
-    pub fn nonce(mut self, value: U256) -> TransactionBuilder<T> {
+    pub fn nonce(mut self, value: U256) -> Self {
         self.nonce = Some(value);
         self
     }
 
     /// Specify the resolve condition, if not specified will default to waiting
     /// for the transaction to be mined (but not confirmed by any extra blocks).
-    pub fn resolve(mut self, value: ResolveCondition) -> TransactionBuilder<T> {
+    pub fn resolve(mut self, value: ResolveCondition) -> Self {
         self.resolve = Some(value);
         self
     }
 
     /// Specify the number of confirmations to use for the confirmation options.
     /// This is a utility method for specifying the resolve condition.
-    pub fn confirmations(mut self, value: usize) -> TransactionBuilder<T> {
+    pub fn confirmations(mut self, value: usize) -> Self {
         self.resolve = match self.resolve {
             Some(ResolveCondition::Confirmed(params)) => {
                 Some(ResolveCondition::Confirmed(ConfirmParams {
@@ -295,7 +295,7 @@ pub struct EstimateGasFuture<T: Transport>(CompatCallFuture<T, U256>);
 
 impl<T: Transport> EstimateGasFuture<T> {
     /// Create a instance from a `TransactionBuilder`.
-    pub fn from_builder(builder: TransactionBuilder<T>) -> EstimateGasFuture<T> {
+    pub fn from_builder(builder: TransactionBuilder<T>) -> Self {
         let eth = builder.web3.eth();
 
         let from = builder.from.map(|account| account.address());
@@ -312,7 +312,7 @@ impl<T: Transport> EstimateGasFuture<T> {
         EstimateGasFuture::from_request(eth, request)
     }
 
-    fn from_request(eth: Eth<T>, request: CallRequest) -> EstimateGasFuture<T> {
+    fn from_request(eth: Eth<T>, request: CallRequest) -> Self {
         // NOTE(nlordell): work around issue tomusdrw/rust-web3#290; while this
         //   bas been fixed in master, it has not been released yet
         EstimateGasFuture(
@@ -576,7 +576,7 @@ enum SendState<T: Transport> {
 
 impl<T: Transport> SendFuture<T> {
     /// Creates a new future from a `TransactionBuilder`
-    pub fn from_builder(mut builder: TransactionBuilder<T>) -> SendFuture<T> {
+    pub fn from_builder(mut builder: TransactionBuilder<T>) -> Self {
         let web3 = builder.web3.clone().into();
         let resolve = Some(builder.resolve.take().unwrap_or_default());
         let state = SendState::Building(BuildFuture::from_builder(builder));

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -59,7 +59,7 @@ pub struct DynTransport {
 
 impl DynTransport {
     /// Wrap a `Transport` in a `DynTransport`
-    pub fn new<F, T>(inner: T) -> DynTransport
+    pub fn new<F, T>(inner: T) -> Self
     where
         F: Future<Item = Value, Error = Web3Error> + Send + 'static,
         T: Transport<Out = F> + 'static,


### PR DESCRIPTION
Prefer `Self` over the typename - this is a stylistic change that helps with the builder patterns and makes refactoring a little easier.

Closes #110 

On hold pending merge of #105 