### PR TITLE
Now or Never

### DIFF
--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -304,7 +304,7 @@ mod tests {
         transport.add_response(json!(network_id)); // estimate gas response
         let networks = Deployments::new(artifact);
         let instance = InstanceDeployedFuture::new(web3, networks)
-            .wait()
+            .immediate()
             .expect("successful deployment");
 
         transport.assert_request("net_version", &[]);

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -396,7 +396,7 @@ mod tests {
         transport.add_response(json!(
             "0x000000000000000000000000000000000000000000000000000000000000002a"
         )); // call response
-        let result = tx.call().wait().expect("call error");
+        let result = tx.call().immediate().expect("call error");
 
         assert_eq!(result, 42.into());
         transport.assert_request(
@@ -430,7 +430,7 @@ mod tests {
         transport.add_response(json!(
             "0x0000000000000000000000000000000000000000000000000000000000000000"
         ));
-        tx.call().wait().expect("call error");
+        tx.call().immediate().expect("call error");
 
         transport.assert_request(
             "eth_call",
@@ -482,7 +482,7 @@ mod tests {
         transport.add_response(json!(
             "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000076d65737361676500000000000000000000000000000000000000000000000000"
         )); // call response
-        let result = tx.call().wait();
+        let result = tx.call().immediate();
         assert!(
             match &result {
                 Err(MethodError {
@@ -508,7 +508,7 @@ mod tests {
         ));
 
         transport.add_response(json!("0x"));
-        let result = tx.call().wait();
+        let result = tx.call().immediate();
         assert!(
             match &result {
                 Err(MethodError {

--- a/src/future.rs
+++ b/src/future.rs
@@ -10,6 +10,7 @@ use web3::Transport;
 
 /// Utility type for a future that might be ready. Similar to `MaybeDone` but
 /// not fused.
+#[derive(Debug)]
 pub struct MaybeReady<F: Future>(Either<Ready<F::Output>, F>);
 
 impl<F: Future + Unpin> MaybeReady<F> {

--- a/src/test/prelude.rs
+++ b/src/test/prelude.rs
@@ -2,20 +2,20 @@
 
 pub use crate::test::macros::*;
 pub use crate::test::transport::TestTransport;
+use futures::future::FutureExt;
 pub use serde_json::json;
 use std::future::Future;
 pub use web3::api::Web3;
 
-/// Temporary solution to work around the issue that async tests are not stable
-/// and the extra boiler plate of setting up an executor is inconvenient.
-/// TODO(nlordell): remove once async tests stablalize
-pub trait FutureWaitExt: Future {
+/// An extension future to assert that a future resolves immediately.
+pub trait FutureImmediateExt: Future {
     /// Block thread on a future completing.
-    fn wait(self) -> Self::Output;
+    fn immediate(self) -> Self::Output;
 }
 
-impl<F: Future + Sized> FutureWaitExt for F {
-    fn wait(self) -> Self::Output {
-        futures::executor::block_on(self)
+impl<F: Future + Sized> FutureImmediateExt for F {
+    fn immediate(self) -> Self::Output {
+        self.now_or_never()
+            .expect("future did not resolve immediately")
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -666,7 +666,7 @@ mod tests {
         );
         transport.assert_no_more_requests();
 
-        let estimate_gas = estimate_gas.wait().expect("success");
+        let estimate_gas = estimate_gas.immediate().expect("success");
         assert_eq!(estimate_gas, 0x42.into());
     }
 
@@ -684,7 +684,7 @@ mod tests {
         transport.add_response(json!(accounts)); // get accounts
         let tx = TransactionBuilder::new(web3)
             .build()
-            .wait()
+            .immediate()
             .expect("get accounts success")
             .request()
             .expect("transaction request");
@@ -722,7 +722,7 @@ mod tests {
             .from(Account::Locked(from, pw.into(), None))
             .to(to)
             .build()
-            .wait()
+            .immediate()
             .expect("sign succeeded")
             .raw()
             .expect("raw transaction");
@@ -765,7 +765,7 @@ mod tests {
             .from(Account::Offline(key.clone(), None))
             .to(to)
             .build()
-            .wait()
+            .immediate()
             .expect("sign succeeded")
             .raw()
             .expect("raw transaction");
@@ -790,7 +790,7 @@ mod tests {
             .gas_price(gas_price)
             .nonce(nonce)
             .build()
-            .wait()
+            .immediate()
             .expect("sign succeeded")
             .raw()
             .expect("raw transaction");
@@ -822,7 +822,7 @@ mod tests {
             .nonce(42.into())
             .resolve(ResolveCondition::Pending)
             .send()
-            .wait()
+            .immediate()
             .expect("transaction success");
 
         // assert that all the parameters are being used and that no extra
@@ -883,13 +883,13 @@ mod tests {
         let tx_raw = builder
             .clone()
             .build()
-            .wait()
+            .immediate()
             .expect("failed to sign transaction")
             .raw()
             .expect("offline transactions always build into raw transactions");
         let tx_receipt = builder
             .send()
-            .wait()
+            .immediate()
             .expect("send with confirmations failed");
 
         assert_eq!(tx_receipt.hash(), tx_hash);
@@ -934,11 +934,11 @@ mod tests {
         let tx_raw = builder
             .clone()
             .build()
-            .wait()
+            .immediate()
             .expect("failed to sign transaction")
             .raw()
             .expect("offline transactions always build into raw transactions");
-        let result = builder.send().wait();
+        let result = builder.send().immediate();
 
         assert!(
             match &result {


### PR DESCRIPTION
Right now, tests use `futures::future::block_on` to wait for futures to resolve. This can be problematic if code causes tests to deadlock (because of a bug for example). Instead tests should use `FutureExt::now_or_never` which returns an `Option<Future::Output>` that is `Some(value)` if the future resolved immediately or `None` if it didn't. This asserts that test futures resolve immediately which is the case for all our tests.

We wrap `now_or_never` in an `FutureImmediateExt::immediate` helper method that additionally panics if the future did not resolve immediately for our tests.

Closes #120.

### Test Plan

CI 