### PR TITLE
Import macros first

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -30,7 +30,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::prelude::*;
 
     #[test]
     fn simple_keccak_hash() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,12 @@
 //!     .await?;
 //! ```
 
+#[cfg(test)]
+#[allow(missing_docs)]
+#[macro_use]
+#[path = "test/macros.rs"]
+mod test_macros;
+
 pub mod contract;
 pub mod errors;
 mod future;
@@ -131,7 +137,6 @@ pub mod private {
 #[cfg(test)]
 #[allow(missing_docs)]
 mod test {
-    pub mod macros;
     pub mod prelude;
     pub mod transport;
 }

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -3,7 +3,6 @@
 /// # Panics
 ///
 /// If the address is invalid.
-#[macro_export]
 macro_rules! addr {
     ($value:expr) => {
         $value[2..]
@@ -12,14 +11,11 @@ macro_rules! addr {
     };
 }
 
-pub use addr;
-
 /// Parse a string uint256 of the form "0x...".
 ///
 /// # Panics
 ///
 /// If the uint is invalid.
-#[macro_export]
 macro_rules! uint {
     ($value:expr) => {
         $value[2..]
@@ -28,14 +24,11 @@ macro_rules! uint {
     };
 }
 
-pub use uint;
-
 /// Parse a string 256-bit hash of the form "0x...".
 ///
 /// # Panics
 ///
 /// If the hash is invalid.
-#[macro_export]
 macro_rules! hash {
     ($value:expr) => {
         $value[2..]
@@ -44,32 +37,24 @@ macro_rules! hash {
     };
 }
 
-pub use hash;
-
 /// Parse hex encoded string of the form "0x...".
 ///
 /// # Panics
 ///
 /// If the hex string is invalid.
-#[macro_export]
 macro_rules! bytes {
     ($value:expr) => {
         serde_json::from_str::<web3::types::Bytes>(&format!("\"{}\"", $value)).expect("valid bytes")
     };
 }
 
-pub use bytes;
-
 /// Parse a string 256-bit private key of the form "0x...".
 ///
 /// # Panics
 ///
 /// If the private key is invalid.
-#[macro_export]
 macro_rules! key {
     ($value:expr) => {
         ethsign::SecretKey::from_raw(&hash!($value)[..]).expect("valid key")
     };
 }
-
-pub use key;

--- a/src/test/prelude.rs
+++ b/src/test/prelude.rs
@@ -1,6 +1,5 @@
 //! Prelude module with common types used for unit tests.
 
-pub use crate::test::macros::*;
 pub use crate::test::transport::TestTransport;
 use futures::future::FutureExt;
 pub use serde_json::json;


### PR DESCRIPTION
Import test macros at the start of `lib.rs`. This was done because macro visibility rules can be a little [unintuitive](https://danielkeep.github.io/tlborm/book/mbe-min-scoping.html) and were done a bit wrong for test macros.

### Test Plan

CI