### PR TITLE
Manual deployment address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ jobs:
         #   `truffle develop` exits as soon as it gets an EOF from STDIN.
         - tail -f /dev/null | yarn --cwd examples/truffle start > /dev/null &
         - cargo run --example async
-        - cargo run --example linked
+        - cargo run --example deployments
         - cargo run --package examples-generate
+        - cargo run --example linked
         - cargo run --example rinkeby
         - kill %1
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ yarn start
   cargo run --example async
   ```
 
+- The `deployments` example illustrates how the `deployments` parameter can be
+  specified when generating a contract with the `ethcontract::contract!` macro.
+  This can be useful for specifying addresses in testing environments that are
+  deterministic but either not included, or inacurate in the artifact's
+  `networks` property (when for example the contract is developed upstream, but
+  a separte testnet deployment wants to be used).
+  ```sh
+  cargo run --example deployments
+  ```
+
 - The `generator` example (actually a separate crate to be able to have a build
   script) demonstrates how the generator API can be used for creating type-safe
   bindings to a smart contract with a `build.rs` build script.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -9,3 +9,4 @@ pub mod truffle;
 pub use crate::bytecode::Bytecode;
 pub use crate::truffle::Artifact;
 pub use ethabi::{self as abi, Contract as Abi};
+pub use web3::types::Address;

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 [dependencies]
 ethcontract-generate = { version = "0.2.0", path = "../generate" }
 syn = "1.0"
+
+[dev-dependencies]
+quote = "1.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 
 [dependencies]
 ethcontract-generate = { version = "0.2.0", path = "../generate" }
+proc-macro2 = "1.0"
 syn = "1.0"
 
 [dev-dependencies]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -9,8 +9,6 @@ use ethcontract_generate::{parse_address, Address, Builder};
 use proc_macro::TokenStream;
 use syn::ext::IdentExt;
 use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
-use syn::punctuated::Punctuated;
-use syn::token::{Brace, FatArrow};
 use syn::{braced, parse_macro_input, Error as SynError, Ident, LitInt, LitStr, Token};
 
 /// Proc macro to generate type-safe bindings to a contract. See
@@ -222,12 +220,15 @@ mod tests {
                 4 => "0x0123456789012345678901234567890123456789",
             },
         );
-        assert_eq!(args.parameters, &[
-            Parameter::Crate("foobar".into()),
-            Parameter::Deployments(vec![
-                deployment(1, "0x000102030405060708090a0b0c0d0e0f10111213"),
-                deployment(4, "0x0123456789012345678901234567890123456789"),
-            ]),
-        ]);
+        assert_eq!(
+            args.parameters,
+            &[
+                Parameter::Crate("foobar".into()),
+                Parameter::Deployments(vec![
+                    deployment(1, "0x000102030405060708090a0b0c0d0e0f10111213"),
+                    deployment(4, "0x0123456789012345678901234567890123456789"),
+                ]),
+            ]
+        );
     }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -69,46 +69,6 @@ impl Parse for ContractArgs {
             artifact_path,
             parameters,
         })
-
-        /*
-        while !input.is_empty() {
-            if input.is_empty() {
-                // allow trailing commas
-                break;
-            }
-
-            let param = input.call(Ident::parse_any)?;
-            match param.to_string().as_str() {
-                "crate" => {
-                    input.parse::<Token![=]>()?;
-                    let ident = input.call(Ident::parse_any)?;
-                    let name = format!("{}", ident.unraw());
-                    builder = builder.with_runtime_crate_name(&name);
-                }
-                "deployments" => {
-                    braced!(content in input);
-                    let deployments =
-                        content.parse_terminated::<_, Token![,]>(Deployment::parse)?;
-                    for deployment in deployments {}
-                    let network_id: u32 = content.parse::<LitInt>()?.base10_parse()?;
-                    content.parse::<Token![=>]>()?;
-                    let address: LitStr = content.parse()?;
-                    content.parse_ter
-                }
-                _ => {
-                    return Err(ParseError::new(
-                        param.span(),
-                        format!("unexpected named parameter `{}`", param),
-                    ))
-                }
-            }
-        }
-
-        Ok(ContractArgs {
-            artifact_path,
-            builder,
-        })
-        */
     }
 }
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -9,7 +9,9 @@ use ethcontract_generate::Builder;
 use proc_macro::TokenStream;
 use syn::ext::IdentExt;
 use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
-use syn::{parse_macro_input, Error as SynError, Ident, LitStr, Token};
+use syn::punctuated::Punctuated;
+use syn::token::{FatArrow, Brace};
+use syn::{braced, LitInt, parse_macro_input, Error as SynError, Ident, LitStr, Token};
 
 /// Proc macro to generate type-safe bindings to a contract. See
 /// [`ethcontract`](ethcontract) module level documentation for more information.
@@ -17,7 +19,7 @@ use syn::{parse_macro_input, Error as SynError, Ident, LitStr, Token};
 pub fn contract(input: proc_macro::TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as ContractArgs);
     let artifact_span = args.artifact_path.span();
-    args.builder
+    args.into_builder()
         .generate()
         .map(|bindings| bindings.into_tokens())
         .unwrap_or_else(|e| SynError::new(artifact_span, e.to_string()).to_compile_error())
@@ -27,35 +29,58 @@ pub fn contract(input: proc_macro::TokenStream) -> TokenStream {
 /// Contract procedural macro arguments.
 struct ContractArgs {
     artifact_path: LitStr,
-    builder: Builder,
+    parameters: Punctuated<Parameter, Token![,]>,
 }
 
-// TODO(nlordell): Due to limitation with the proc-macro Span API, we can't
-//   currently get a path the the file where we were called from; therefore,
-//   the path will always be rooted on the cargo manifest directory.
-//   Eventually we can use the `Span::source_file` API to have a better
-//   experience.
+impl ContractArgs {
+    fn into_builder(self) -> Builder {
+        todo!()
+    }
+}
 
 impl Parse for ContractArgs {
     fn parse(input: ParseStream) -> ParseResult<Self> {
-        let artifact_path: LitStr = input.parse()?;
-        let mut builder = Builder::new(artifact_path.value());
+        // TODO(nlordell): Due to limitation with the proc-macro Span API, we
+        //   can't currently get a path the the file where we were called from;
+        //   therefore, the path will always be rooted on the cargo manifest
+        //   directory. Eventually we can use the `Span::source_file` API to
+        //   have a better experience.
+        let artifact_path = input.parse()?;
 
-        while !input.is_empty() {
+        if !input.is_empty() {
             input.parse::<Token![,]>()?;
+        }
+        let parameters = input.parse_terminated(Parameter::parse)?;
+
+        Ok(ContractArgs {
+            artifact_path,
+            parameters,
+        })
+
+        /*
+        while !input.is_empty() {
             if input.is_empty() {
                 // allow trailing commas
                 break;
             }
 
             let param = input.call(Ident::parse_any)?;
-            input.parse::<Token![=]>()?;
-
             match param.to_string().as_str() {
                 "crate" => {
+                    input.parse::<Token![=]>()?;
                     let ident = input.call(Ident::parse_any)?;
                     let name = format!("{}", ident.unraw());
                     builder = builder.with_runtime_crate_name(&name);
+                }
+                "deployments" => {
+                    braced!(content in input);
+                    let deployments =
+                        content.parse_terminated::<_, Token![,]>(Deployment::parse)?;
+                    for deployment in deployments {}
+                    let network_id: u32 = content.parse::<LitInt>()?.base10_parse()?;
+                    content.parse::<Token![=>]>()?;
+                    let address: LitStr = content.parse()?;
+                    content.parse_ter
                 }
                 _ => {
                     return Err(ParseError::new(
@@ -69,6 +94,52 @@ impl Parse for ContractArgs {
         Ok(ContractArgs {
             artifact_path,
             builder,
+        })
+        */
+    }
+}
+
+enum Parameter {
+    Crate(Token![=], Ident),
+    Deployments(Brace, Punctuated<Deployment, Token![,]>),
+}
+
+impl Parse for Parameter {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
+        let name = input.call(Ident::parse_any)?;
+        let param = match name.to_string().as_str() {
+            "crate" => Parameter::Crate(input.parse()?, input.call(Ident::parse_any)?),
+            "deployments" => {
+                let content;
+                Parameter::Deployments(
+                    braced!(content in input),
+                    content.parse_terminated(Deployment::parse)?,
+                )
+            }
+            _ => {
+                return Err(ParseError::new(
+                    name.span(),
+                    format!("unexpected named parameter `{}`", name),
+                ))
+            }
+        };
+
+        Ok(param)
+    }
+}
+
+struct Deployment {
+    network_id: LitInt,
+    _sep: FatArrow,
+    address: LitStr,
+}
+
+impl Parse for Deployment {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
+        Ok(Deployment {
+            network_id: input.parse()?,
+            _sep: input.parse()?,
+            address: input.parse()?,
         })
     }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -5,19 +5,20 @@
 
 extern crate proc_macro;
 
-use ethcontract_generate::Builder;
+use ethcontract_generate::{parse_address, Address, Builder};
 use proc_macro::TokenStream;
 use syn::ext::IdentExt;
 use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
 use syn::punctuated::Punctuated;
-use syn::token::{FatArrow, Brace};
-use syn::{braced, LitInt, parse_macro_input, Error as SynError, Ident, LitStr, Token};
+use syn::token::{Brace, FatArrow};
+use syn::{braced, parse_macro_input, Error as SynError, Ident, LitInt, LitStr, Token};
 
 /// Proc macro to generate type-safe bindings to a contract. See
 /// [`ethcontract`](ethcontract) module level documentation for more information.
 #[proc_macro]
-pub fn contract(input: proc_macro::TokenStream) -> TokenStream {
+pub fn contract(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as ContractArgs);
+
     let artifact_span = args.artifact_path.span();
     args.into_builder()
         .generate()
@@ -29,12 +30,23 @@ pub fn contract(input: proc_macro::TokenStream) -> TokenStream {
 /// Contract procedural macro arguments.
 struct ContractArgs {
     artifact_path: LitStr,
-    parameters: Punctuated<Parameter, Token![,]>,
+    parameters: Vec<Parameter>,
 }
 
 impl ContractArgs {
     fn into_builder(self) -> Builder {
-        todo!()
+        let mut builder = Builder::new(&self.artifact_path.value());
+        for parameter in self.parameters.into_iter() {
+            builder = match parameter {
+                Parameter::Crate(name) => builder.with_runtime_crate_name(name),
+                Parameter::Deployments(deployments) => {
+                    deployments.into_iter().fold(builder, |builder, d| {
+                        builder.add_deployment(d.network_id, d.address)
+                    })
+                }
+            };
+        }
+        builder
     }
 }
 
@@ -50,7 +62,10 @@ impl Parse for ContractArgs {
         if !input.is_empty() {
             input.parse::<Token![,]>()?;
         }
-        let parameters = input.parse_terminated(Parameter::parse)?;
+        let parameters = input
+            .parse_terminated::<_, Token![,]>(Parameter::parse)?
+            .into_iter()
+            .collect();
 
         Ok(ContractArgs {
             artifact_path,
@@ -99,22 +114,31 @@ impl Parse for ContractArgs {
     }
 }
 
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
 enum Parameter {
-    Crate(Token![=], Ident),
-    Deployments(Brace, Punctuated<Deployment, Token![,]>),
+    Crate(String),
+    Deployments(Vec<Deployment>),
 }
 
 impl Parse for Parameter {
     fn parse(input: ParseStream) -> ParseResult<Self> {
         let name = input.call(Ident::parse_any)?;
         let param = match name.to_string().as_str() {
-            "crate" => Parameter::Crate(input.parse()?, input.call(Ident::parse_any)?),
+            "crate" => {
+                input.parse::<Token![=]>()?;
+                let name = input.call(Ident::parse_any)?.to_string();
+
+                Parameter::Crate(name)
+            }
             "deployments" => {
                 let content;
-                Parameter::Deployments(
-                    braced!(content in input),
-                    content.parse_terminated(Deployment::parse)?,
-                )
+                braced!(content in input);
+                let deployments = content
+                    .parse_terminated::<_, Token![,]>(Deployment::parse)?
+                    .into_iter()
+                    .collect();
+
+                Parameter::Deployments(deployments)
             }
             _ => {
                 return Err(ParseError::new(
@@ -128,18 +152,82 @@ impl Parse for Parameter {
     }
 }
 
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
 struct Deployment {
-    network_id: LitInt,
-    _sep: FatArrow,
-    address: LitStr,
+    network_id: u32,
+    address: Address,
 }
 
 impl Parse for Deployment {
     fn parse(input: ParseStream) -> ParseResult<Self> {
+        let network_id = input.parse::<LitInt>()?.base10_parse()?;
+        input.parse::<Token![=>]>()?;
+        let address = {
+            let literal = input.parse::<LitStr>()?;
+            parse_address(&literal.value()).map_err(|err| ParseError::new(literal.span(), err))?
+        };
+
         Ok(Deployment {
-            network_id: input.parse()?,
-            _sep: input.parse()?,
-            address: input.parse()?,
+            network_id,
+            address,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! contract_args {
+        ($($arg:tt)*) => {{
+            use syn::parse::Parser;
+            <ContractArgs as Parse>::parse
+                .parse2(quote::quote! { $($arg)* })
+                .expect("failed to parse contract args")
+        }};
+    }
+
+    fn deployment(network_id: u32, address: &str) -> Deployment {
+        Deployment {
+            network_id,
+            address: parse_address(address).expect("failed to parse deployment address"),
+        }
+    }
+
+    #[test]
+    fn parse_contract_args() {
+        let args = contract_args!("path/to/artifact.json");
+        assert_eq!(args.artifact_path.value(), "path/to/artifact.json");
+    }
+
+    #[test]
+    fn parse_contract_args_with_parameter() {
+        let args = contract_args!("artifact.json", crate = foobar);
+        assert_eq!(args.parameters, &[Parameter::Crate("foobar".into())]);
+    }
+
+    #[test]
+    fn crate_parameter_accepts_keywords() {
+        let args = contract_args!("artifact.json", crate = crate);
+        assert_eq!(args.parameters, &[Parameter::Crate("crate".into())]);
+    }
+
+    #[test]
+    fn parse_contract_args_with_parameters() {
+        let args = contract_args!(
+            "artifact.json",
+            crate = foobar,
+            deployments {
+                1 => "0x000102030405060708090a0b0c0d0e0f10111213",
+                4 => "0x0123456789012345678901234567890123456789",
+            },
+        );
+        assert_eq!(args.parameters, &[
+            Parameter::Crate("foobar".into()),
+            Parameter::Deployments(vec![
+                deployment(1, "0x000102030405060708090a0b0c0d0e0f10111213"),
+                deployment(4, "0x0123456789012345678901234567890123456789"),
+            ]),
+        ]);
     }
 }

--- a/derive/src/spanned.rs
+++ b/derive/src/spanned.rs
@@ -1,0 +1,50 @@
+//! Provides implementation for helpers used in parsing `TokenStream`s where the
+//! data ultimately does not care about its `Span` information, but it is useful
+//! during intermediate processing.
+
+use proc_macro2::Span;
+use std::ops::Deref;
+use syn::parse::{Parse, ParseStream, Result as ParseResult};
+
+/// Trait that abstracts functionality for inner data that can be parsed and
+/// wrapped with a specific `Span`.
+pub trait ParseInner: Sized {
+    fn spanned_parse(input: ParseStream) -> ParseResult<(Span, Self)>;
+}
+
+impl<T: Parse> ParseInner for T {
+    fn spanned_parse(input: ParseStream) -> ParseResult<(Span, Self)> {
+        Ok((input.span(), T::parse(input)?))
+    }
+}
+
+impl<T: ParseInner> Parse for Spanned<T> {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
+        let (span, value) = T::spanned_parse(input)?;
+        Ok(Spanned(span, value))
+    }
+}
+
+/// A struct that captures `Span` information for inner parsable data.
+#[cfg_attr(test, derive(Clone, Debug))]
+pub struct Spanned<T>(Span, T);
+
+impl<T> Spanned<T> {
+    /// Retrieves the captured `Span` information for the parsed data.
+    pub fn span(&self) -> Span {
+        self.0
+    }
+
+    /// Retrieves the inner data.
+    pub fn into_inner(self) -> T {
+        self.1
+    }
+}
+
+impl<T> Deref for Spanned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.1
+    }
+}

--- a/examples/deployments.rs
+++ b/examples/deployments.rs
@@ -1,0 +1,36 @@
+use ethcontract::web3::api::Web3;
+use ethcontract::web3::transports::Http;
+use futures::compat::Future01CompatExt;
+
+ethcontract::contract!(
+    "examples/truffle/build/contracts/RustCoin.json",
+    deployments {
+        5777 => "0x0123456789012345678901234567890123456789",
+    },
+);
+
+fn main() {
+    futures::executor::block_on(run());
+}
+
+async fn run() {
+    let (eloop, http) = Http::new("http://localhost:9545").expect("transport failed");
+    eloop.into_remote();
+    let web3 = Web3::new(http);
+
+    let network_id = web3
+        .net()
+        .version()
+        .compat()
+        .await
+        .expect("failed to get network ID");
+    let instance = RustCoin::deployed(&web3)
+        .await
+        .expect("faild to find deployment");
+
+    println!(
+        "RustCoin deployed on networks {} at {:?}",
+        network_id,
+        instance.address()
+    );
+}

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -71,8 +71,8 @@ impl Context {
     #[cfg(test)]
     fn empty() -> Self {
         Context {
-            full_path: PathBuf::new(),
-            artifact_path: Literal::string(""),
+            full_path: "/Contract.json".into(),
+            artifact_path: Literal::string("Contract.json"),
             artifact: Artifact::empty(),
             runtime_crate: util::ident("ethcontract"),
             contract_name: util::ident("Contract"),

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -12,7 +12,7 @@ mod types;
 use crate::util;
 use crate::Args;
 use anyhow::{Context as _, Result};
-use ethcontract_common::{Artifact, Address};
+use ethcontract_common::{Address, Artifact};
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
 use std::collections::HashMap;

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -33,11 +33,13 @@ pub(crate) struct Context {
     runtime_crate: Ident,
     /// The contract name as an identifier.
     contract_name: Ident,
+    /// The original args used for creating the context.
+    args: Args,
 }
 
 impl Context {
     /// Create a context from the code generation arguments.
-    fn from_args(args: &Args) -> Result<Self> {
+    fn from_args(args: Args) -> Result<Self> {
         let full_path = fs::canonicalize(&args.artifact_path).with_context(|| {
             format!(
                 "unable to open file from working dir {} with path {}",
@@ -61,11 +63,24 @@ impl Context {
             artifact,
             runtime_crate,
             contract_name,
+            args,
         })
+    }
+
+    #[cfg(test)]
+    fn empty() -> Self {
+        Context {
+            full_path: PathBuf::new(),
+            artifact_path: Literal::string(""),
+            artifact: Artifact::empty(),
+            runtime_crate: util::ident("ethcontract"),
+            contract_name: util::ident("Contract"),
+            args: Args::new(""),
+        }
     }
 }
 
-pub(crate) fn expand(args: &Args) -> Result<TokenStream> {
+pub(crate) fn expand(args: Args) -> Result<TokenStream> {
     let cx = Context::from_args(args)?;
     let contract = expand_contract(&cx).with_context(|| {
         format!(

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -71,7 +71,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
 
                 let artifact = Self::artifact();
                 let address = match network_id {
-                    #( #deployments ),*
+                    #( #deployments )*
                     _ => artifact.networks.get(network_id)?.address,
                 };
                 let instance = Instance::at(web3, artifact.abi.clone(), address);

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -2,6 +2,7 @@ use crate::contract::{methods, Context};
 use crate::util;
 use anyhow::{Context as _, Result};
 use ethcontract_common::abi::{Param, ParamType};
+use ethcontract_common::Address;
 use inflector::Inflector;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
@@ -18,12 +19,21 @@ pub(crate) fn expand(cx: &Context) -> Result<TokenStream> {
 }
 
 fn expand_deployed(cx: &Context) -> TokenStream {
-    if cx.artifact.networks.is_empty() {
+    if cx.artifact.networks.is_empty() && cx.args.deployments.is_empty() {
         return quote! {};
     }
 
     let ethcontract = &cx.runtime_crate;
     let contract_name = &cx.contract_name;
+
+    let deployments = cx.args.deployments.iter().map(|(network_id, address)| {
+        let network_id = Literal::string(network_id);
+        let address = expand_address(cx, *address);
+
+        quote! {
+            #network_id => #address,
+        }
+    });
 
     quote! {
         impl #contract_name {
@@ -60,12 +70,13 @@ fn expand_deployed(cx: &Context) -> TokenStream {
                 use #ethcontract::Instance;
 
                 let artifact = Self::artifact();
-                artifact
-                    .networks
-                    .get(network_id)
-                    .map(move |network| Self {
-                        instance: Instance::at(web3, artifact.abi.clone(), network.address),
-                    })
+                let address = match network_id {
+                    #( #deployments ,)*
+                    _ => artifact.networks.get(network_id)?.address,
+                };
+                let instance = Instance::at(web3, artifact.abi.clone(), address);
+
+                Some(Self { instance })
             }
         }
     }
@@ -171,4 +182,45 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
             }
         }
     })
+}
+
+/// Expands an `Address` into a literal representation that can be used with
+/// quasi-quoting for code generation.
+fn expand_address(cx: &Context, address: Address) -> TokenStream {
+    let ethcontract = &cx.runtime_crate;
+    let bytes = address
+        .as_bytes()
+        .iter()
+        .copied()
+        .map(Literal::u8_unsuffixed);
+
+    quote! {
+        #ethcontract::Address([#( #bytes ),*])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_address_value() {
+        let cx = Context::empty();
+
+        assert_eq!(
+            expand_address(&cx, Address::zero()).to_string(),
+            quote! {
+                ethcontract::Address([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+            }
+            .to_string(),
+        );
+
+        assert_eq!(
+            expand_address(&cx, "000102030405060708090a0b0c0d0e0f10111213".parse().unwrap()).to_string(),
+            quote! {
+                ethcontract::Address([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+            }
+            .to_string(),
+        );
+    }
 }

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -19,14 +19,14 @@ pub(crate) fn expand(cx: &Context) -> Result<TokenStream> {
 }
 
 fn expand_deployed(cx: &Context) -> TokenStream {
-    if cx.artifact.networks.is_empty() && cx.args.deployments.is_empty() {
+    if cx.artifact.networks.is_empty() && cx.deployments.is_empty() {
         return quote! {};
     }
 
     let ethcontract = &cx.runtime_crate;
     let contract_name = &cx.contract_name;
 
-    let deployments = cx.args.deployments.iter().map(|(network_id, address)| {
+    let deployments = cx.deployments.iter().map(|(network_id, address)| {
         let network_id = Literal::string(&network_id.to_string());
         let address = expand_address(cx, *address);
 

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -71,7 +71,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
 
                 let artifact = Self::artifact();
                 let address = match network_id {
-                    #( #deployments ,)*
+                    #( #deployments ),*
                     _ => artifact.networks.get(network_id)?.address,
                 };
                 let instance = Instance::at(web3, artifact.abi.clone(), address);
@@ -195,7 +195,7 @@ fn expand_address(cx: &Context, address: Address) -> TokenStream {
         .map(Literal::u8_unsuffixed);
 
     quote! {
-        #ethcontract::Address([#( #bytes ),*])
+        #ethcontract::Address::from([#( #bytes ),*])
     }
 }
 
@@ -210,7 +210,7 @@ mod tests {
         assert_eq!(
             expand_address(&cx, Address::zero()).to_string(),
             quote! {
-                ethcontract::Address([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+                ethcontract::Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
             }
             .to_string(),
         );
@@ -218,7 +218,7 @@ mod tests {
         assert_eq!(
             expand_address(&cx, "000102030405060708090a0b0c0d0e0f10111213".parse().unwrap()).to_string(),
             quote! {
-                ethcontract::Address([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+                ethcontract::Address::from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
             }
             .to_string(),
         );

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -27,7 +27,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
     let contract_name = &cx.contract_name;
 
     let deployments = cx.args.deployments.iter().map(|(network_id, address)| {
-        let network_id = Literal::string(network_id);
+        let network_id = Literal::string(&network_id.to_string());
         let address = expand_address(cx, *address);
 
         quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,9 @@
 //!     .execute_confirm()
 //!     .await?;
 //! ```
+//!
+//! See [`contract!`](ethcontract::contract) proc macro documentation for more
+//! information on usage and parameters.
 
 #[cfg(test)]
 #[allow(missing_docs)]


### PR DESCRIPTION
Add ability to manually specify deployment addresses. This closes #99 and #100 .

This PR also adds unit tests in the code generation and derive libraries - so unit tests can be slowly added for code generation as future modification come in.

### Test Plan

Unit tests and new example.