### PR TITLE
[Easy] Update Cargo commands to use `--workspace` instead of `--all`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_script:
 script:
   - cargo build --workspace --all-features --verbose
   - cargo test --workspace --all-features --verbose
-  - cargo fmt --all -- --check
+  - cargo fmt -- --check
   - cargo clippy --workspace --all-features --all-targets -- -D warnings
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,10 +77,10 @@ before_script:
   - (cd examples/truffle; yarn --frozen-lockfile && yarn build)
 
 script:
-  - cargo build --all-features --verbose --all
-  - cargo test --all-features --verbose --all
+  - cargo build --workspace --all-features --verbose
+  - cargo test --workspace --all-features --verbose
   - cargo fmt --all -- --check
-  - cargo clippy --all --all-features --all-targets -- -D warnings
+  - cargo clippy --workspace --all-features --all-targets -- -D warnings
 
 before_cache:
   - rm -rf "$TRAVIS_HOME/.cargo/registry"


### PR DESCRIPTION
Just update the cargo commands since `--all` is deprecated. From the help:
```
$ cargo build --help
# ...
        --all                        Alias for --workspace (deprecated)
        --workspace                  Build all packages in the workspace
# ...
```

Note that `cargo fmt` does not support the `--workspace` flag and `--all` actually has different semantics to `--workspace` for other cargo commands. Currently, `cargo fmt` already formats all packages in the workspace, the `--all` flag additionally formats packages that are imported via path and are outside of the workspace (see discussion [here](https://github.com/rust-lang/rustfmt/issues/3911)). So, for this PR we also remove the `--all` flag as it superfluous.

### Test plan

CI