### PR TITLE
[Easy] Run examples with Truffle instead of Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ jobs:
       rust: stable
       script:
         - |
-          cd examples/truffle
-          yarn start &
+          yarn --cwd examples/truffle start &
           TRUFFLE_PID=$!
-          cd -
         - cargo run --example async
         - cargo run --example linked
         - cargo run --package examples-generate

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,12 @@ jobs:
     - name: "Rust: stable - Examples"
       rust: stable
       script:
-        - |
-          mkfifo /tmp/truffle-in
-          tail -f /tmp/truffle-in | yarn --cwd examples/truffle start > /dev/null &
+        - tail -f /dev/null | yarn --cwd examples/truffle start > /dev/null &
         - cargo run --example async
         - cargo run --example linked
         - cargo run --package examples-generate
         - cargo run --example rinkeby
-        - |
-          kill %1
-          rm /tmp/truffle-in
+        - kill %1
 
     - stage: "Deploy"
       name: "crates.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       rust: stable
       script:
         - |
-          yarn --cwd examples/truffle start > /dev/null &
+          yarn --cwd examples/truffle start <(sleep infinity) >/dev/null &
           TRUFFLE_PID=$!
         - cargo run --example async
         - cargo run --example linked

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ jobs:
       rust: stable
       script:
         - |
-          mkfifo in
-          tail -f in | yarn --cwd examples/truffle start &
+          mkfifo /tmp/truffle-in
+          tail -f /tmp/truffle-in | yarn --cwd examples/truffle start > /dev/null &
         - cargo run --example async
         - cargo run --example linked
         - cargo run --package examples-generate
         - cargo run --example rinkeby
         - |
           kill %1
-          rm in
+          rm /tmp/truffle-in
 
     - stage: "Deploy"
       name: "crates.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       rust: stable
       script:
         - |
-          yarn --cwd examples/truffle start &
+          yarn --cwd examples/truffle start > /dev/null &
           TRUFFLE_PID=$!
         - cargo run --example async
         - cargo run --example linked

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,17 @@ jobs:
   include:
     - name: "Rust: stable - Examples"
       rust: stable
-      services:
-        - docker
-      install:
-        - docker pull trufflesuite/ganache-cli:v6.7.0
       script:
-        - docker run -d -p 9545:8545 trufflesuite/ganache-cli:v6.7.0
+        - |
+          cd examples/truffle
+          yarn start &
+          TRUFFLE_PID=$!
+          cd -
         - cargo run --example async
         - cargo run --example linked
         - cargo run --package examples-generate
         - cargo run --example rinkeby
+        - kill -9 $TRUFFLE_PID
 
     - stage: "Deploy"
       name: "crates.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,15 @@ jobs:
       rust: stable
       script:
         - |
-          yarn --cwd examples/truffle start <(sleep infinity) >/dev/null &
-          TRUFFLE_PID=$!
+          mkfifo in
+          tail -f in | yarn --cwd examples/truffle start &
         - cargo run --example async
         - cargo run --example linked
         - cargo run --package examples-generate
         - cargo run --example rinkeby
-        - kill -9 $TRUFFLE_PID
+        - |
+          kill %1
+          rm in
 
     - stage: "Deploy"
       name: "crates.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ jobs:
     - name: "Rust: stable - Examples"
       rust: stable
       script:
-        # NOTE: We pipe `tail -f /dev/null` so that the `truffle develop` so
-        #   that the process' STDIN stays open, as `truffle develop` exits as
-        #   soon as it gets an EOF from STDIN.
+        # NOTE: We pipe `tail -f /dev/null` into `yarn start`, which internally
+        #   calls `truffle develop`, so that the process' STDIN stays open, as
+        #   `truffle develop` exits as soon as it gets an EOF from STDIN.
         - tail -f /dev/null | yarn --cwd examples/truffle start > /dev/null &
         - cargo run --example async
         - cargo run --example linked

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ jobs:
     - name: "Rust: stable - Examples"
       rust: stable
       script:
+        # NOTE: We pipe `tail -f /dev/null` so that the `truffle develop` so
+        #   that the process' STDIN stays open, as `truffle develop` exits as
+        #   soon as it gets an EOF from STDIN.
         - tail -f /dev/null | yarn --cwd examples/truffle start > /dev/null &
         - cargo run --example async
         - cargo run --example linked


### PR DESCRIPTION
The motivation behind this is that the examples are designed specifically to run with `truffle develop` so that the same truffle installation used for building the example contracts can be used to run a development node.

Previously, to make things simpler, we used Docker in the Travis CI to run all of the examples and configured the Docker-ized Ganache to have the same default parameters as `truffle develop`. This is a bit fragile as the CI will not actually verify that updates to the Truffle package will not break the current examples and example assumptions (such as default network ID and default port).

This PR addresses that and makes the CI run the examples as is documented in the README. Alternatively, the README and examples could be updated to use Docker and Ganache, but that would add another additional dependency on Docker. The advantage of using Truffle is that it is already needed for building the examples.

### Test plan

CI