### PR TITLE
Gate `ethcontract-derive` dependency on feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ to Ethereum smart contracts.
 name = "ethcontract"
 
 [features]
-default = []
+default = ["ethcontract-derive"]
 samples = []
 
 [workspace]
@@ -30,7 +30,7 @@ members = [
 
 [dependencies]
 ethcontract-common = { version = "0.2.0", path = "./common" }
-ethcontract-derive = { version = "0.2.0", path = "./derive" }
+ethcontract-derive = { version = "0.2.0", path = "./derive", optional = true}
 ethsign = "0.7"
 futures = { version = "0.3", features = ["compat"] }
 futures-timer = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ to Ethereum smart contracts.
 name = "ethcontract"
 
 [features]
-default = ["ethcontract-derive"]
+default = ["derive"]
+derive = ["ethcontract-derive"]
 samples = []
 
 [workspace]

--- a/examples/generate/Cargo.toml
+++ b/examples/generate/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-ethcontract = { path = "../.." }
+ethcontract = { path = "../..", no-default-features = true }
 futures = "0.3"
 web3 = "0.8"
 

--- a/generate/README.md
+++ b/generate/README.md
@@ -17,6 +17,8 @@ generator:
 ```toml
 [dependencies]
 ethcontract = "..."
+# `no-default-features = true` can be specified if the `contract` macro is
+# not needed because only generate is being used.
 
 [build-dependencies]
 ethcontract-generate = "..."

--- a/generate/README.md
+++ b/generate/README.md
@@ -16,9 +16,7 @@ generator:
 
 ```toml
 [dependencies]
-ethcontract = "..."
-# `no-default-features = true` can be specified if the `contract` macro is
-# not needed because only generate is being used.
+ethcontract = { version = "...", no-default-features = true }
 
 [build-dependencies]
 ethcontract-generate = "..."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::transaction::Account;
 pub use crate::transport::DynTransport;
 pub use ethcontract_common as common;
 pub use ethcontract_common::truffle::Artifact;
-pub use ethcontract_derive::contract;
+#[cfg(feature = "ethcontract-derive")] pub use ethcontract_derive::contract;
 pub use ethsign::{self, Protected, SecretKey};
 pub use serde_json as json;
 pub use web3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,8 @@ pub use crate::transaction::Account;
 pub use crate::transport::DynTransport;
 pub use ethcontract_common as common;
 pub use ethcontract_common::truffle::Artifact;
-#[cfg(feature = "ethcontract-derive")] pub use ethcontract_derive::contract;
+#[cfg(feature = "ethcontract-derive")]
+pub use ethcontract_derive::contract;
 pub use ethsign::{self, Protected, SecretKey};
 pub use serde_json as json;
 pub use web3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::transaction::Account;
 pub use crate::transport::DynTransport;
 pub use ethcontract_common as common;
 pub use ethcontract_common::truffle::Artifact;
-#[cfg(feature = "ethcontract-derive")]
+#[cfg(feature = "derive")]
 pub use ethcontract_derive::contract;
 pub use ethsign::{self, Protected, SecretKey};
 pub use serde_json as json;


### PR DESCRIPTION
This will allow for dependent crates to not build ethcontract-derive when
using the ethcontract-generate API.

fixes #91