### PR TITLE
[Easy] Correctly specify no 'default-features' for generate example

### DIFF
--- a/examples/generate/Cargo.toml
+++ b/examples/generate/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-ethcontract = { path = "../..", no-default-features = true }
+ethcontract = { path = "../..", default-features = false }
 futures = "0.3"
 web3 = "0.8"
 

--- a/generate/README.md
+++ b/generate/README.md
@@ -16,7 +16,7 @@ generator:
 
 ```toml
 [dependencies]
-ethcontract = { version = "...", no-default-features = true }
+ethcontract = { version = "...", default-features = false }
 
 [build-dependencies]
 ethcontract-generate = "..."


### PR DESCRIPTION
Looks like the correct way to disable default features in a `Cargo.toml` is `default-features = false`. This fixes that.

### Test Plan

1) See the build warning here: https://travis-ci.org/gnosis/ethcontract-rs/jobs/642532349#L271
  ```
warning: /home/travis/build/gnosis/ethcontract-rs/examples/generate/Cargo.toml: unused manifest key: dependencies.ethcontract.no-default-features
  ```
  Or checkout https://github.com/gnosis/ethcontract-rs/commit/0607e87002d2299d93264e1219e09774f9f7c2a3 and run a `cargo build`.

2) Check that this is no longer the case.