### PR TITLE
[Easy] Remove unused dependency

### DIFF
--- a/examples/generate/Cargo.toml
+++ b/examples/generate/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [dependencies]
 ethcontract = { path = "../..", no-default-features = true }
 futures = "0.3"
-web3 = "0.8"
 
 [build-dependencies]
 ethcontract-generate = { path = "../../generate" }


### PR DESCRIPTION
Removes an unused dependency in the examples. This is no longer needed as `ethcontract` re-exports everything that is required to interact with contracts.

### Test Plan

CI