### PR TITLE
[Easy] Check UTF-8 conversion on protected password bytes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ use ethcontract_common::abi::{Error as AbiError, ErrorKind as AbiErrorKind, Func
 use ethsign::Error as SignError;
 use jsonrpc_core::Error as JsonrpcError;
 use std::num::ParseIntError;
+use std::str::Utf8Error;
 use thiserror::Error;
 use web3::contract::Error as Web3ContractError;
 use web3::error::Error as Web3Error;
@@ -72,6 +73,11 @@ pub enum ExecutionError {
     /// signed transaction to a node without any local accounts.
     #[error("no local accounts")]
     NoLocalAccounts,
+
+    /// An error indicating that the password used in unlocking an account for
+    /// signing contained an invalid UTF-8 string.
+    #[error("invalid UTF-8 password: {0}")]
+    PasswordUtf8(#[from] Utf8Error),
 
     /// An error occured while signing a transaction offline.
     #[error("offline sign error: {0}")]

--- a/src/transaction/build.rs
+++ b/src/transaction/build.rs
@@ -700,7 +700,7 @@ mod tests {
                 ExecutionError::PasswordUtf8(_) => true,
                 _ => false,
             },
-            "expected no invalid UTF-8 password error but got '{:?}'",
+            "expected invalid UTF-8 password error but got '{:?}'",
             err
         );
     }

--- a/src/transaction/build.rs
+++ b/src/transaction/build.rs
@@ -558,7 +558,7 @@ mod tests {
             TransactionRequestOptions::default(),
         )
         .immediate()
-        .expect_err("unexpected success building tx");
+        .expect_err("unexpected success building transaction");
 
         transport.assert_request("eth_accounts", &[]);
         transport.assert_no_more_requests();
@@ -681,7 +681,7 @@ mod tests {
         let web3 = Web3::new(transport.clone());
 
         let from = addr!("0x9876543210987654321098765432109876543210");
-        let pw = b"\xff";
+        let pw = b"\xff"; // 0xff is not a valid UTF-8 codepoint
 
         let err = BuildTransactionSignedWithLockedAccountFuture::new(
             web3,


### PR DESCRIPTION
This was identified as an issue in #137. There is no good reason we should be using `from_utf8_unchecked` here, and is probably incorrect.

### Test Plan

New test case!