### PR TITLE
[Easy] Add new unit test for deployed

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -24,6 +24,7 @@ pub use self::method::{
 
 /// Represents a contract instance at an address. Provides methods for
 /// contract interaction.
+#[derive(Debug, Clone)]
 pub struct Instance<T: Transport> {
     web3: Web3<T>,
     abi: Abi,

--- a/src/contract/deployed.rs
+++ b/src/contract/deployed.rs
@@ -117,4 +117,31 @@ mod tests {
 
         assert_eq!(instance.address(), address);
     }
+
+    #[test]
+    fn deployed_not_found() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        let network_id = "42";
+
+        transport.add_response(json!(network_id)); // get network ID response
+        let networks = Deployments::new(Artifact::empty());
+        let err = InstanceDeployedFuture::new(web3, networks)
+            .immediate()
+            .expect_err("unexpected success getting deployed contract");
+
+        transport.assert_request("net_version", &[]);
+        transport.assert_no_more_requests();
+
+        assert!(
+            match &err {
+                DeployError::NotFound(id) => id == network_id,
+                _ => false,
+            },
+            "expected network {} not found error but got '{:?}'",
+            network_id,
+            err
+        );
+    }
 }


### PR DESCRIPTION
This PR adds a new unit test to the deployed future for testing how it acts when a network is not found. Note that `Instance` now implements `Debug`, this is used in the unit test.

### Test Plan

New unit test!