### PR TITLE
[Easy] Fix clippy warnings

### DIFF
--- a/generate/src/contract/common.rs
+++ b/generate/src/contract/common.rs
@@ -24,7 +24,6 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
         }
 
         #[allow(dead_code)]
-        #[allow(clippy::too_many_arguments, clippy::type_complexity)]
         impl #contract_name {
             /// Retrieves the truffle artifact used to generate the type safe API
             /// for this contract.

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -36,6 +36,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
     });
 
     quote! {
+        #[allow(dead_code)]
         impl #contract_name {
             /// Locates a deployed contract based on the current network ID
             /// reported by the `web3` provider.

--- a/generate/src/contract/methods.rs
+++ b/generate/src/contract/methods.rs
@@ -25,6 +25,8 @@ pub(crate) fn expand(cx: &Context) -> Result<TokenStream> {
     }
 
     Ok(quote! {
+        #[allow(dead_code)]
+        #[allow(clippy::too_many_arguments, clippy::type_complexity)]
         impl #contract_name {
             #( #functions )*
         }


### PR DESCRIPTION
With the refactored generation code, we could get clippy warnings on functions that had too many parameters; this is because the generated code is split into multiple `impl` blocks. This fixes that.

### Test Plan

CI