### PR TITLE
[Easy] Re-export JSONRPC core crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub use ethcontract_common as common;
 pub use ethcontract_common::truffle::Artifact;
 #[cfg(feature = "derive")]
 pub use ethcontract_derive::contract;
+pub use jsonrpc_core as jsonrpc;
 pub use secret::{Password, PrivateKey};
 pub use serde_json as json;
 pub use web3;


### PR DESCRIPTION
This PR re-export the `jsonrpc_core` crate as its version is tightly coupled with `web3`. This should arguably be re-exported by `web3` (as it does with the `futures` crate) but here should be good enough for now.

### Test Plan

Check it still compiles.