### PR TITLE
[Easy] Fix nightly redundant import lint

### DIFF
--- a/common/src/bytecode.rs
+++ b/common/src/bytecode.rs
@@ -3,7 +3,6 @@
 //! for libraries that require linking.
 
 use crate::errors::{BytecodeError, LinkError};
-use hex;
 use serde::de::{Error as DeError, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashSet;


### PR DESCRIPTION
The nightly build was catching this lint, lets fix it nice and early.

Here is the lint in question: https://travis-ci.org/gnosis/ethcontract-rs/jobs/646874470#L1329

### Test Plan

CI + check that the nightly build is no longer failing.