### PR TITLE
[Easy] Allow dead code on impl block

### DIFF
--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -139,6 +139,7 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
     };
 
     Ok(quote! {
+        #[allow(dead_code)]
         impl #contract_name {
             #doc
             pub fn builder<F, T>(


### PR DESCRIPTION
There is another impl block missing an `#[allow(dead_code)]`, this PR fixes that.

### Test Plan

CI.