### PR TITLE
More convenient TestTransport

### DIFF
--- a/src/test/transport.rs
+++ b/src/test/transport.rs
@@ -10,15 +10,24 @@ use web3::futures::future::{self, FutureResult};
 use web3::helpers;
 use web3::{RequestId, Transport};
 
-/// Type alias for request method and value pairs
-type Requests = Vec<(String, Vec<Value>)>;
+/// Request
+#[derive(Debug)]
+pub struct Request {
+    pub method: String,
+    pub params: Vec<Value>,
+}
+
+/// RequestResponse
+#[derive(Debug)]
+pub struct RequestResponse {
+    request: Request,
+    response: Value,
+}
 
 /// Test transport
 #[derive(Debug, Default, Clone)]
 pub struct TestTransport {
-    asserted: usize,
-    requests: Rc<RefCell<Requests>>,
-    responses: Rc<RefCell<VecDeque<Value>>>,
+    expected_request_responses: Rc<RefCell<VecDeque<RequestResponse>>>,
 }
 
 impl Transport for TestTransport {
@@ -26,18 +35,25 @@ impl Transport for TestTransport {
 
     fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
         let request = helpers::build_request(1, method, params.clone());
-        self.requests.borrow_mut().push((method.into(), params));
-        (self.requests.borrow().len(), request)
+        let id = self.expected_request_responses.borrow().len();
+        let expected = self
+            .expected_request_responses
+            .borrow()
+            .get(0)
+            .ok_or_else(|| format!("unexpected request: {:?}", request))
+            .unwrap();
+        assert_eq!(expected.request.method, method);
+        assert_eq!(expected.request.params, params);
+        (id, request)
     }
 
     fn send(&self, id: RequestId, request: Call) -> Self::Out {
-        match self.responses.borrow_mut().pop_front() {
-            Some(response) => future::ok(response),
-            None => {
-                println!("Unexpected request (id: {:?}): {:?}", id, request);
-                future::err(Error::Unreachable)
-            }
-        }
+        self.expected_request_responses
+            .borrow_mut()
+            .pop_front()
+            .map(|expected| future::ok(expected.response))
+            .ok_or_else(|| format!("unexpected request (id: {:?}): {:?}", id, request))
+            .unwrap()
     }
 }
 
@@ -47,34 +63,17 @@ impl TestTransport {
         Default::default()
     }
 
-    /// Add a response to an eventual request.
-    pub fn add_response(&mut self, value: Value) {
-        self.responses.borrow_mut().push_back(value);
+    /// Add an expected request and response that will be sent.
+    pub fn add_request_response(&mut self, method: String, params: Vec<Value>, response: Value) {
+        self.expected_request_responses
+            .borrow_mut()
+            .push_back(RequestResponse {
+                request: Request { method, params },
+                response,
+            });
     }
 
-    /// Assert that a request was made.
-    pub fn assert_request(&mut self, method: &str, params: &[Value]) {
-        let idx = self.asserted;
-        self.asserted += 1;
-
-        let (m, p) = self
-            .requests
-            .borrow()
-            .get(idx)
-            .expect("Expected result.")
-            .clone();
-        assert_eq!(&m, method);
-        assert_eq!(&p[..], params);
-    }
-
-    /// Assert that there are no more pending requests.
     pub fn assert_no_more_requests(&self) {
-        let requests = self.requests.borrow();
-        assert_eq!(
-            self.asserted,
-            requests.len(),
-            "Expected no more requests, got: {:?}",
-            &requests[self.asserted..]
-        );
+        assert!(self.expected_request_responses.borrow().is_empty());
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -107,15 +107,20 @@ mod tests {
         let mut transport = TestTransport::new();
         let dyn_transport = DynTransport::new(transport.clone());
 
-        // assert that the underlying transport prepares the request.
+        // assert that the underlying transport prepares the request and returns
+        // the response.
+        transport.add_request_response("test".to_string(), vec![json!(28)], json!(true));
         let (id, call) = dyn_transport.prepare("test", vec![json!(28)]);
-        transport.assert_request("test", &[json!(28)]);
         transport.assert_no_more_requests();
 
-        // assert that the underlying transport returns the response.
-        transport.add_response(json!(true));
         let response = dyn_transport.send(id, call).wait().expect("success");
         assert_eq!(response, json!(true));
+
+    #[test]
+    #[should_panic]
+    fn dyn_transport_panics() {
+        let mut transport = TestTransport::new();
+        let dyn_transport = DynTransport::new(transport.clone());
 
         // assert that the transport layer gets propagated - it errors here since
         // we did not provide the test transport with a response
@@ -124,7 +129,5 @@ mod tests {
             .wait()
             .err()
             .expect("failed");
-        transport.assert_request("test", &[json!(42)]);
-        transport.assert_no_more_requests();
     }
 }


### PR DESCRIPTION
This changes `TestTransport` to have one `add_request_response` method instead of separate `assert_request` and `add_response`.
In my opinion this is nicer because you have the request and response right next to each other in tests and not first all responses and then all requests.

I only changed `TestTransport` and one test as an example so it doesn't compile yet. If you @nlordell  think its a good change I can apply it to all tests.

Other minor changes:
* created structs instead of the tuples
* turned the future error in `send` into a panic because I wasn't sure why it wasn't a panic in the first place