### PR TITLE
Fix deployed transaction signing

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -150,9 +150,10 @@ mod tests {
         //     gasPrice: '6000000000',
         //     value: '0',
         //     data: '0x600080fd', // revert()
+        //     chainId: 5777,
         // }, '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318')
         // ```
-        // which produced the following output for chain ID 5777:
+        // which produced the following output:
         // ```
         // {
         //     messageHash: '0x0526a7987ac9f046668309e842c25a5388a853f09af138bc614160248d93b8ed',

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -165,10 +165,10 @@ mod tests {
 
         let tx = TransactionData {
             nonce: 42.into(),
-            gas: 21_000.into(),
+            gas: 2_000_000.into(),
             gas_price: 6_000_000_000u64.into(),
             to: None,
-            value: 1_337_000_000u64.into(),
+            value: 0.into(),
             data: &bytes!("0x600080fd"),
         };
         let key = key!("0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318");

--- a/src/transaction/build.rs
+++ b/src/transaction/build.rs
@@ -326,7 +326,7 @@ pub struct BuildOfflineSignedTransactionFuture<T: Transport> {
     /// The private key to use for signing.
     key: PrivateKey,
     /// The recepient address.
-    to: Address,
+    to: Option<Address>,
     /// The ETH value to be sent with the transaction.
     value: U256,
     /// The ABI encoded call parameters,
@@ -347,7 +347,7 @@ impl<T: Transport> BuildOfflineSignedTransactionFuture<T> {
         gas_price: GasPrice,
         options: TransactionOptions,
     ) -> Self {
-        let to = options.to.unwrap_or_else(Address::zero);
+        let to = options.to;
         let value = options.value.unwrap_or_else(U256::zero);
 
         let params = {
@@ -361,7 +361,7 @@ impl<T: Transport> BuildOfflineSignedTransactionFuture<T> {
                     eth.clone(),
                     CallRequest {
                         from: Some(from),
-                        to,
+                        to: to.unwrap_or_else(Address::zero),
                         gas: None,
                         gas_price: None,
                         value: options.value,


### PR DESCRIPTION
This PR fixes signing for deployed contracts. We were serializing contract deployment (a transaction with no `to`) as if it were a transaction to address 0, which is wrong.

Closes #181 

### Test Plan

New unit test generated with web3.