### PR TITLE
Add support for parsing revert errors from Partiy nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ ethcontract-common = { version = "0.3.0", path = "./common" }
 ethcontract-derive = { version = "0.3.0", path = "./derive", optional = true}
 futures = { version = "0.3", features = ["compat"] }
 futures-timer = "3.0"
+hex = "0.4"
 jsonrpc-core = "14.0"
 lazy_static = "1.4"
 pin-project = "0.4"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@
 
 mod ganache;
 mod parity;
-pub mod revert;
+pub(crate) mod revert;
 
 use ethcontract_common::abi::{Error as AbiError, ErrorKind as AbiErrorKind, Function};
 use secp256k1::Error as Secp256k1Error;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -89,7 +89,7 @@ pub enum ExecutionError {
     ConfirmTimeout,
 
     /// Transaction failure (e.g. out of gas or revert).
-    #[error("transaction failed: {0}")]
+    #[error("transaction failed: {0:?}")]
     Failure(H256),
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,10 @@
 //! Module with common error types.
 
+mod ganache;
+mod parity;
+pub mod revert;
+
 use ethcontract_common::abi::{Error as AbiError, ErrorKind as AbiErrorKind, Function};
-use jsonrpc_core::Error as JsonrpcError;
 use secp256k1::Error as Secp256k1Error;
 use std::num::ParseIntError;
 use thiserror::Error;
@@ -92,16 +95,16 @@ pub enum ExecutionError {
 
 impl From<Web3Error> for ExecutionError {
     fn from(err: Web3Error) -> Self {
-        match err {
-            Web3Error::Rpc(ref err) if get_error_param(err, "error") == Some("revert") => {
-                let reason = get_error_param(err, "reason").map(|reason| reason.to_owned());
-                ExecutionError::Revert(reason)
+        if let Web3Error::Rpc(jsonrpc_err) = &err {
+            if let Some(err) = ganache::get_encoded_error(&jsonrpc_err) {
+                return err;
             }
-            Web3Error::Rpc(ref err) if get_error_param(err, "error") == Some("invalid opcode") => {
-                ExecutionError::InvalidOpcode
+            if let Some(err) = parity::get_encoded_error(&jsonrpc_err) {
+                return err;
             }
-            err => ExecutionError::Web3(err),
         }
+
+        ExecutionError::Web3(err)
     }
 }
 
@@ -109,26 +112,6 @@ impl From<AbiError> for ExecutionError {
     fn from(err: AbiError) -> Self {
         ExecutionError::AbiDecode(err.into())
     }
-}
-
-/// Gets an error parameters from a JSON RPC error.
-///
-/// These parameters are the fields inside the transaction object (by tx hash)
-/// inside the error data object. Note that we don't need to know the fake tx
-/// hash for getting the error params as there should only be one.
-fn get_error_param<'a>(err: &'a JsonrpcError, name: &str) -> Option<&'a str> {
-    fn is_hash_str(s: &str) -> bool {
-        s.len() == 66 && s[2..].parse::<H256>().is_ok()
-    }
-
-    err.data
-        .as_ref()?
-        .as_object()?
-        .iter()
-        .filter_map(|(k, v)| if is_hash_str(k) { Some(v) } else { None })
-        .next()?
-        .get(name)?
-        .as_str()
 }
 
 /// Error that can occur while executing a contract call or transaction.
@@ -193,34 +176,15 @@ impl From<Secp256k1Error> for InvalidPrivateKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jsonrpc_core::ErrorCode;
-    use serde_json::{json, Value};
-
-    fn ganache_rpc_error(data: Value) -> Web3Error {
-        Web3Error::Rpc(JsonrpcError {
-            code: ErrorCode::from(-32000),
-            message: "error".to_owned(),
-            data: Some(data),
-        })
-    }
 
     #[test]
-    fn execution_error_from_ganache_revert_with_message() {
-        let web3_err = ganache_rpc_error(json!({
-            "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
-               "error": "revert",
-               "program_counter": 42,
-               "return": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000076d65737361676500000000000000000000000000000000000000000000000000",
-               "reason": "message",
-            },
-            "stack": "RuntimeError: VM Exception while processing transaction: revert contract reverted as requested ...",
-            "name": "RuntimeError",
-        }));
+    fn from_ganache_encoded_error() {
+        let web3_err = Web3Error::Rpc(ganache::rpc_error("invalid opcode", None));
         let err = ExecutionError::from(web3_err);
 
         assert!(
             match err {
-                ExecutionError::Revert(Some(ref reason)) if reason == "message" => true,
+                ExecutionError::InvalidOpcode => true,
                 _ => false,
             },
             "bad error conversion {:?}",
@@ -229,39 +193,8 @@ mod tests {
     }
 
     #[test]
-    fn execution_error_from_ganache_revert() {
-        let web3_err = ganache_rpc_error(json!({
-            "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
-               "error": "revert",
-               "program_counter": 42,
-               "return": "0x",
-            },
-            "stack": "RuntimeError: VM Exception while processing transaction: revert ...",
-            "name": "RuntimeError",
-        }));
-        let err = ExecutionError::from(web3_err);
-
-        assert!(
-            match err {
-                ExecutionError::Revert(None) => true,
-                _ => false,
-            },
-            "bad error conversion {:?}",
-            err
-        );
-    }
-
-    #[test]
-    fn execution_error_from_ganache_invalid_opcode() {
-        let web3_err = ganache_rpc_error(json!({
-            "0x991fef26454cd1b52e37041295833c24b883e03a2c654fd03bb67e66955e540b": {
-               "error": "invalid opcode",
-               "program_counter": 42,
-               "return": "0x",
-            },
-            "stack": "RuntimeError: VM Exception while processing transaction: invalid opcode...",
-            "name": "RuntimeError",
-        }));
+    fn from_parity_encoded_error() {
+        let web3_err = Web3Error::Rpc(parity::rpc_error("Bad instruction fd"));
         let err = ExecutionError::from(web3_err);
 
         assert!(

--- a/src/errors/ganache.rs
+++ b/src/errors/ganache.rs
@@ -1,0 +1,119 @@
+//! This module implements Ganache specific error decoding in order to try and
+//! provide more accurate errors from Ganache nodes.
+
+use crate::errors::ExecutionError;
+use jsonrpc_core::Error as JsonrpcError;
+use web3::types::H256;
+
+/// Tries to get a more accurate error from a generic Ganache JSON RPC error.
+/// Returns `None` when a more accurate error cannot be determined.
+pub fn get_encoded_error(err: &JsonrpcError) -> Option<ExecutionError> {
+    match get_error_param(&err, "error") {
+        Some("revert") => {
+            let reason = get_error_param(&err, "reason").map(|reason| reason.to_owned());
+            Some(ExecutionError::Revert(reason))
+        }
+        Some("invalid opcode") => Some(ExecutionError::InvalidOpcode),
+        _ => None,
+    }
+}
+
+/// Gets an error parameters from a Ganache JSON RPC error.
+///
+/// these parameters are the fields inside the transaction object (by tx hash)
+/// inside the error data object. Note that we don't need to know the fake tx
+/// hash for getting the error params as there should only be one.
+fn get_error_param<'a>(err: &'a JsonrpcError, name: &str) -> Option<&'a str> {
+    fn is_hash_str(s: &str) -> bool {
+        s.len() == 66 && s[2..].parse::<H256>().is_ok()
+    }
+
+    err.data
+        .as_ref()?
+        .as_object()?
+        .iter()
+        .filter_map(|(k, v)| if is_hash_str(k) { Some(v) } else { None })
+        .next()?
+        .get(name)?
+        .as_str()
+}
+
+#[cfg(test)]
+pub use tests::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::revert;
+    use crate::test::prelude::*;
+    use jsonrpc_core::ErrorCode;
+    use std::borrow::Cow;
+
+    pub fn rpc_error(error: &str, reason: Option<&str>) -> JsonrpcError {
+        let return_data: Cow<str> = if let Some(reason) = reason {
+            revert::encode_reason_hex(reason).into()
+        } else {
+            "0x".into()
+        };
+
+        JsonrpcError {
+            code: ErrorCode::from(-32000),
+            message: "error".to_owned(),
+            data: Some(json!({
+                "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f": {
+                   "error": error,
+                   "program_counter": 42,
+                   "return": return_data,
+                   "reason": reason,
+                },
+                "stack": "RuntimeError: VM Exception while processing transaction ...",
+                "name": "RuntimeError",
+            })),
+        }
+    }
+
+    #[test]
+    fn execution_error_from_revert_with_message() {
+        let jsonrpc_err = rpc_error("revert", Some("message"));
+        let err = get_encoded_error(&jsonrpc_err);
+
+        assert!(
+            match &err {
+                Some(ExecutionError::Revert(Some(reason))) if reason == "message" => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn execution_error_from_revert() {
+        let jsonrpc_err = rpc_error("revert", None);
+        let err = get_encoded_error(&jsonrpc_err);
+
+        assert!(
+            match err {
+                Some(ExecutionError::Revert(None)) => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn execution_error_from_invalid_opcode() {
+        let jsonrpc_err = rpc_error("invalid opcode", None);
+        let err = get_encoded_error(&jsonrpc_err);
+
+        assert!(
+            match err {
+                Some(ExecutionError::InvalidOpcode) => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+}

--- a/src/errors/parity.rs
+++ b/src/errors/parity.rs
@@ -1,0 +1,101 @@
+//! This module implements Parity specific error decoding in order to try and
+//! provide more accurate errors from Parity nodes.
+
+use crate::errors::{revert, ExecutionError};
+use jsonrpc_core::Error as JsonrpcError;
+
+/// Revert error discriminant.
+const REVERTED: &str = "Reverted 0x";
+/// Invalid op-code error discriminant.
+const INVALID: &str = "Bad instruction";
+
+/// Tries to get a more accurate error from a generic Parity JSON RPC error.
+/// Returns `None` when a more accurate error cannot be determined.
+pub fn get_encoded_error(err: &JsonrpcError) -> Option<ExecutionError> {
+    let message = get_error_message(err)?;
+    if message.starts_with(REVERTED) {
+        let hex = &message[REVERTED.len()..];
+        if hex.is_empty() {
+            return Some(ExecutionError::Revert(None));
+        } else {
+            let bytes = hex::decode(&hex).ok()?;
+            let reason = revert::decode_reason(&bytes)?;
+            return Some(ExecutionError::Revert(Some(reason)));
+        }
+    } else if message.starts_with(INVALID) {
+        return Some(ExecutionError::InvalidOpcode);
+    }
+
+    None
+}
+
+/// Returns the error message from the JSON RPC error data.
+fn get_error_message(err: &JsonrpcError) -> Option<&'_ str> {
+    err.data.as_ref().and_then(|data| data.as_str())
+}
+
+#[cfg(test)]
+pub use tests::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+    use jsonrpc_core::ErrorCode;
+
+    pub fn rpc_error(data: &str) -> JsonrpcError {
+        JsonrpcError {
+            code: ErrorCode::from(-32015),
+            message: "vm execution error".to_owned(),
+            data: Some(json!(data)),
+        }
+    }
+
+    #[test]
+    fn execution_error_from_revert_with_message() {
+        let jsonrpc_err = rpc_error(&format!(
+            "Reverted {}",
+            revert::encode_reason_hex("message")
+        ));
+        let err = get_encoded_error(&jsonrpc_err);
+
+        assert!(
+            match &err {
+                Some(ExecutionError::Revert(Some(reason))) if reason == "message" => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn execution_error_from_revert() {
+        let jsonrpc_err = rpc_error("Reverted 0x");
+        let err = get_encoded_error(&jsonrpc_err);
+
+        assert!(
+            match &err {
+                Some(ExecutionError::Revert(None)) => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn execution_error_from_invalid_opcode() {
+        let jsonrpc_err = rpc_error("Bad instruction fd");
+        let err = get_encoded_error(&jsonrpc_err);
+
+        assert!(
+            match err {
+                Some(ExecutionError::InvalidOpcode) => true,
+                _ => false,
+            },
+            "bad error conversion {:?}",
+            err
+        );
+    }
+}

--- a/src/errors/revert.rs
+++ b/src/errors/revert.rs
@@ -1,0 +1,70 @@
+//! Module implements decoding ABI encoded revert reasons.
+
+use crate::hash;
+use ethcontract_common::abi::{self, ParamType};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// The ABI function selector for identifying encoded revert reasons.
+    static ref ERROR_SELECTOR: [u8; 4] = hash::function_selector("Error(string)");
+}
+
+/// Decodes an ABI encoded revert reason. Returns `Some(reason)` when the ABI
+/// encoded bytes represent a revert reason and `None` otherwise.
+///
+/// These reasons are prefixed by a 4-byte error followed by an ABI encoded
+/// string.
+pub fn decode_reason(bytes: &[u8]) -> Option<String> {
+    if (bytes.len() + 28) % 32 != 0 || bytes[0..4] != ERROR_SELECTOR[..] {
+        // check to make sure that the length is of the form `4 + (n * 32)`
+        // bytes and it starts with `keccak256("Error(string)")` which means
+        // it is an encoded revert reason from Geth nodes.
+        return None;
+    }
+
+    let reason = abi::decode(&[ParamType::String], &bytes[4..])
+        .ok()?
+        .pop()
+        .expect("decoded single parameter will yield single token")
+        .to_string()
+        .expect("decoded string parameter will always be a string");
+
+    Some(reason)
+}
+
+#[cfg(test)]
+pub use tests::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethcontract_common::abi::{Function, Param, Token};
+
+    pub fn encode_reason(reason: &str) -> Vec<u8> {
+        let revert = Function {
+            name: "Error".into(),
+            inputs: vec![Param {
+                name: "".into(),
+                kind: ParamType::String,
+            }],
+            outputs: Vec::new(),
+            constant: true,
+        };
+        revert
+            .encode_input(&[Token::String(reason.into())])
+            .expect("error encoding revert reason")
+    }
+
+    pub fn encode_reason_hex(reason: &str) -> String {
+        let encoded = encode_reason(reason);
+        format!("0x{}", hex::encode(encoded))
+    }
+
+    #[test]
+    fn decode_revert_reason() {
+        let reason = "ethcontract rocks!";
+        let encoded = encode_reason(reason);
+
+        assert_eq!(decode_reason(&encoded).as_deref(), Some(reason));
+    }
+}


### PR DESCRIPTION
Currently revert errors from Parity nodes do not get property decoded into `ExecutionError::Revert`. Since the full nodes we run at Gnosis are Parity nodes, that is a problem. This PR adds support for that.

Fixed #185

### Test Plan

New unit tests