### PR TITLE
[Easy] Make ethcontract errors Sync

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -189,6 +189,7 @@ impl From<Secp256k1Error> for InvalidPrivateKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error;
 
     #[test]
     fn from_ganache_encoded_error() {
@@ -236,12 +237,12 @@ mod tests {
     }
 
     #[test]
-    fn all_errors_are_send_and_sync() {
-        fn assert_send_and_sync<T: Send + Sync>() {}
+    fn all_errors_are_boxable_errors() {
+        fn assert_boxable_error<T: Error + Send + Sync + 'static>() {}
 
-        assert_send_and_sync::<DeployError>();
-        assert_send_and_sync::<ExecutionError>();
-        assert_send_and_sync::<MethodError>();
-        assert_send_and_sync::<InvalidPrivateKey>();
+        assert_boxable_error::<DeployError>();
+        assert_boxable_error::<ExecutionError>();
+        assert_boxable_error::<MethodError>();
+        assert_boxable_error::<InvalidPrivateKey>();
     }
 }

--- a/src/errors/web3contract.rs
+++ b/src/errors/web3contract.rs
@@ -1,0 +1,39 @@
+//! This module implements adapted `web3` error types so that the errors in
+//! the parent module all implement `Sync`. Otherwise, dealing with propagating
+//! errors across threads can be tricky.
+
+use ethcontract_common::abi::{Error as AbiError, ErrorKind as AbiErrorKind};
+use thiserror::Error;
+use web3::error::Error as Web3Error;
+
+/// An addapted `web3::contract::Error` that implements `Sync`.
+#[derive(Debug, Error)]
+pub enum Web3ContractError {
+    /// Invalid output type requested by the caller.
+    #[error("invalid output type: {0}")]
+    InvalidOutputType(String),
+    /// Eth ABI error.
+    #[error("ABI error: {0}")]
+    Abi(AbiErrorKind),
+    /// RPC error.
+    #[error("API error: {0}")]
+    Api(Web3Error),
+}
+
+impl From<web3::contract::Error> for Web3ContractError {
+    fn from(err: web3::contract::Error) -> Self {
+        match err {
+            web3::contract::Error::InvalidOutputType(value) => {
+                Web3ContractError::InvalidOutputType(value)
+            }
+            web3::contract::Error::Abi(AbiError(kind, _)) => Web3ContractError::Abi(kind),
+            web3::contract::Error::Api(err) => Web3ContractError::Api(err),
+        }
+    }
+}
+
+impl From<AbiError> for Web3ContractError {
+    fn from(err: AbiError) -> Self {
+        Web3ContractError::Abi(err.0)
+    }
+}


### PR DESCRIPTION
Currently, `ethcontract` error types are not all `Sync`. This can be annoying when passing around errors in a multithreaded environment or when boxing errors into `Box<std::error::Error + Send + Sync + 'static>`.

This fixes this.

### Test Plan

Add compile-time assertions to ensure error types implement `Send + Sync + 'static`