### PR TITLE
Update scripts

### DIFF
--- a/ci/bump.sh
+++ b/ci/bump.sh
@@ -65,11 +65,11 @@ function msg {
 msg "Updating Cargo manifests with new version '$version':"
 for manifest in Cargo.toml */Cargo.toml examples/*/Cargo.toml; do
 	msg "  - $manifest"
-	sed -iEe 's/^((ethcontract-[a-z]+ = \{ )?version = )"[0-9\.]+"/\1"'"$version"'"' **/Cargo.toml
+	sed -i -E -e 's/^((ethcontract-[a-z]+ = \{ )?version) = "[0-9\.]+"/\1 = "'"$version"'"/g' "$manifest"
 done
 
 msg "Updating npm packages with new version '$version':"
 for package in examples/*/package.json; do
 	msg "  - $package"
-	sed -iEe 's/^(  "version": )"[0-9\.]+"/\1"'"$version"'"' examples/truffle/package.json
+	sed -i -E -e 's/^(  "version":) "[0-9\.]+"/\1 "'"$version"'"/g' "$package"
 done

--- a/ci/bump.sh
+++ b/ci/bump.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -e
+
+verbose=""
+version=""
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		-v|--verbose) verbose=t;;
+		-h|--help) cat << EOF
+ci/bump.sh
+Bump the version of all crates and packages in the repository to VERSION
+
+USAGE:
+    $0 [OPTIONS] <VERSION>
+
+OPTIONS:
+    -v, --verbose           Use verbose output
+    -h, --help              Prints this help information
+
+ARGUMENTS:
+    VERSION                 The new version to use for the workspace. It must
+                            be a valid SemVer version number of the format
+                            'MAJOR.MINOR.PATCH'.
+EOF
+			exit
+			;;
+		*)
+			if [[ -z "$version" ]]; then
+				version="$1"
+			else
+				>&2 cat << EOF
+ERROR: Invalid option '$1'.
+	   For more information try '$0 --help'
+EOF
+				exit 1
+			fi
+			;;
+	esac
+	shift
+done
+
+if [[ -z "$version" ]]; then
+	>&2 cat << EOF
+ERROR: Missing version argument.
+       For more information try '$0 --help'
+EOF
+	exit 1
+fi
+if [[ ! $version =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	>&2 cat << EOF
+ERROR: Invalid version format.
+       For more information try '$0 --help'
+EOF
+	exit 1
+fi
+version=${version/v/}
+
+function msg {
+	if [[ -n $verbose ]]; then
+		echo $*
+	fi
+}
+
+msg "Updating Cargo manifests with new version '$version':"
+for manifest in Cargo.toml */Cargo.toml examples/*/Cargo.toml; do
+	msg "  - $manifest"
+	sed -iEe 's/^((ethcontract-[a-z]+ = \{ )?version = )"[0-9\.]+"/\1"'"$version"'"' **/Cargo.toml
+done
+
+msg "Updating npm packages with new version '$version':"
+for package in examples/*/package.json; do
+	msg "  - $package"
+	sed -iEe 's/^(  "version": )"[0-9\.]+"/\1"'"$version"'"' examples/truffle/package.json
+done

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -9,8 +9,8 @@ while [[ $# -gt 0 ]]; do
 	case $1 in
 		--token) token="$2"; shift;;
 		--tag) tag="$2"; shift;;
-		--dry-run) options+="--dry-run ";;
-		-v|-vv|--verbose) options+="--verbose ";;
+		--dry-run) options+="$1 ";;
+		-v|-vv|--verbose) options+="$1 ";;
 		-h|--help) cat << EOF
 ci/deploy.sh
 Deploy the workspace to crates.io
@@ -19,17 +19,19 @@ USAGE:
     $0 [OPTIONS]
 
 OPTIONS:
-        --token <TOKEN>             Token to use when uploading
-    -t, --tag <TAG>                 The current tag being deployed
-        --dry-run                   Perform all checks without uploading
-    -v, --verbose                   Use verbose output (-vv very verbose/build.rs output)
-    -h, --help                      Prints this help information
+        --token <TOKEN>     Token to use when uploading
+    -t, --tag <TAG>         The current tag being deployed
+        --dry-run           Perform all checks without uploading
+    -v, --verbose           Use verbose output (-vv very verbose output)
+    -h, --help              Prints this help information
 EOF
+			exit
 			;;
 		*) cat << EOF
-ERROR: Invalid argument '$1'.
+ERROR: Invalid option '$1'.
        For more information try '$0 --help'
 EOF
+			exit 1
 			;;
 	esac
 	shift

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -27,7 +27,7 @@ OPTIONS:
 EOF
 			exit
 			;;
-		*) cat << EOF
+		*) >&2 cat << EOF
 ERROR: Invalid option '$1'.
        For more information try '$0 --help'
 EOF
@@ -40,7 +40,7 @@ done
 function check_manifest_version {
 	version=$(cat $1 | grep '^version' | sed -n 's/version = "\(.*\)"/v\1/p')
 	if [[ ! $version = $tag ]]; then
-		echo "$1 is at $version but expected $tag"
+		>&2 echo "ERROR: $1 is at $version but expected $tag"
 		exit 1
 	fi
 }


### PR DESCRIPTION
This PR updates the utility bash scripts:
- formatting of help in deploy script, as well as properly exiting on bad options and when `--help` is specified
- introduce `bump.sh` which bumps versions of Cargo manifest and package files in the project

### Test Plan

- Checkout this branch
- Rus `ci/deploy.sh --foo` and see that it exits right away with an error
- Rus `ci/deploy.sh --help` and see that it exits right away
- Run `ci/bump.sh 0.4.1` and see all package versions changed to `0.4.1`.