### PR TITLE
Add support for retrieving contract ABIs directly from Etherscan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
         - tail -f /dev/null | yarn --cwd examples/truffle start > /dev/null &
         - cargo run --example async
         - cargo run --example deployments
+        - cargo run --example etherscan
         - cargo run --package examples-generate
         - cargo run --example linked
         - cargo run --example rinkeby

--- a/README.md
+++ b/README.md
@@ -89,13 +89,26 @@ yarn start
 
 There is a provided example that runs with Rinkeby and Infura. Running this
 example is a little more involved to run because it requires a private key with
-funds on Rinkeby (for gas) as well as a Infura project ID in order to connect to
-a node. Parameters are provided to the Rinkeby example by environment variables:
+funds on Rinkeby (for gas) as well as an Infura project ID in order to connect
+to a node. Parameters are provided to the Rinkeby example by environment
+variables:
 
 ```sh
 export PK="private key"
 export INFURA_PROJECT_ID="Infura project ID"
 cargo run --example rinkeby
+```
+
+### Etherscan Example
+
+This example generates contract bindings from a verfied contract on Etherscan
+and then queries some contract state with Infura. Running this example requires
+an Infura project ID in order to connect to a node. Parameters are provided to
+the example by environment variables:
+
+```sh
+export INFURA_PROJECT_ID="Infura project ID"
+cargo run --example etherscan
 ```
 
 ## Sample Contracts Documentation

--- a/common/src/truffle.rs
+++ b/common/src/truffle.rs
@@ -11,6 +11,7 @@ use web3::types::Address;
 
 /// Represents a truffle artifact.
 #[derive(Clone, Debug, Deserialize)]
+#[serde(default = "Artifact::empty")]
 pub struct Artifact {
     /// The contract name
     #[serde(rename = "contractName")]
@@ -90,6 +91,12 @@ pub struct DocEntry {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn parse() {}
+    fn parse_empty() {
+        if let Err(err) = Artifact::from_json("{}") {
+            panic!("error parsing empty artifact: {:?}", err);
+        }
+    }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -10,8 +10,9 @@ mod spanned;
 use crate::spanned::{ParseInner, Spanned};
 use ethcontract_generate::{parse_address, Address, Builder};
 use proc_macro::TokenStream;
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use std::collections::HashSet;
+use std::error::Error;
 use syn::ext::IdentExt;
 use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
 use syn::{braced, parse_macro_input, Error as SynError, Ident, LitInt, LitStr, Token};
@@ -55,12 +56,14 @@ pub fn contract(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as Spanned<ContractArgs>);
 
     let span = args.span();
-    args.into_inner()
-        .into_builder()
-        .generate()
-        .map(|bindings| bindings.into_tokens())
+    expand(args.into_inner())
         .unwrap_or_else(|e| SynError::new(span, e.to_string()).to_compile_error())
         .into()
+}
+
+fn expand(args: ContractArgs) -> Result<TokenStream2, Box<dyn Error>> {
+    let tokens = args.into_builder()?.generate()?.into_tokens();
+    Ok(tokens)
 }
 
 /// Contract procedural macro arguments.
@@ -71,11 +74,12 @@ struct ContractArgs {
 }
 
 impl ContractArgs {
-    fn into_builder(self) -> Builder {
-        let mut builder = Builder::new(&self.artifact_path);
+    fn into_builder(self) -> Result<Builder, Box<dyn Error>> {
+        let mut builder = Builder::from_source_url(&self.artifact_path)?;
         for parameter in self.parameters.into_iter() {
             builder = match parameter {
                 Parameter::Crate(name) => builder.with_runtime_crate_name(name),
+                Parameter::Contract(name) => builder.with_contract_name_override(Some(name)),
                 Parameter::Deployments(deployments) => {
                     deployments.into_iter().fold(builder, |builder, d| {
                         builder.add_deployment(d.network_id, d.address)
@@ -83,7 +87,8 @@ impl ContractArgs {
                 }
             };
         }
-        builder
+
+        Ok(builder)
     }
 }
 
@@ -121,6 +126,7 @@ impl ParseInner for ContractArgs {
 #[cfg_attr(test, derive(Debug, Eq, PartialEq))]
 enum Parameter {
     Crate(String),
+    Contract(String),
     Deployments(Vec<Deployment>),
 }
 
@@ -133,6 +139,12 @@ impl Parse for Parameter {
                 let name = input.call(Ident::parse_any)?.to_string();
 
                 Parameter::Crate(name)
+            }
+            "contract" => {
+                input.parse::<Token![=]>()?;
+                let name = input.parse::<Ident>()?.to_string();
+
+                Parameter::Contract(name)
             }
             "deployments" => {
                 let content;
@@ -242,6 +254,7 @@ mod tests {
         let args = contract_args!(
             "artifact.json",
             crate = foobar,
+            contract = Contract,
             deployments {
                 1 => "0x000102030405060708090a0b0c0d0e0f10111213",
                 4 => "0x0123456789012345678901234567890123456789",
@@ -253,6 +266,7 @@ mod tests {
                 artifact_path: "artifact.json".into(),
                 parameters: vec![
                     Parameter::Crate("foobar".into()),
+                    Parameter::Contract("Contract".into()),
                     Parameter::Deployments(vec![
                         deployment(1, "0x000102030405060708090a0b0c0d0e0f10111213"),
                         deployment(4, "0x0123456789012345678901234567890123456789"),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -25,10 +25,22 @@ use syn::{braced, parse_macro_input, Error as SynError, Ident, LitInt, LitStr, T
 /// ethcontract::contract!("build/contracts/MyContract.json");
 /// ```
 ///
+/// Alternatively, an etherscan URL can be specified. In this case the ABI will
+/// be retrieved and used to generate type-safe contract bindings:
+///
+/// ```ignore
+/// ethcontract::contract!("etherscan:0x0001020304050607080910111213141516171819");
+/// // or
+/// ethcontract::contract!("https://etherscan.io/address/0x0001020304050607080910111213141516171819");
+/// ```
+///
 /// Currently the proc macro accepts additional parameters to configure some
 /// aspects of the code generation. Specifically it accepts:
 /// - `crate`: The name of the `ethcontract` crate. This is useful if the crate
 ///   was renamed in the `Cargo.toml` for whatever reason.
+/// - `contract`: Override the contract name that is used for the generated
+///   type. This is required when using sources that do not provide the contract
+///   name in the artifact JSON such as Etherscan.
 /// - `deployments`: A list of additional addresses of deployed contract for
 ///   specified network IDs. This mapping allows `MyContract::deployed` to work
 ///   for networks that are not included in the Truffle artifact's `networks`
@@ -42,6 +54,7 @@ use syn::{braced, parse_macro_input, Error as SynError, Ident, LitInt, LitStr, T
 /// ethcontract::contract!(
 ///     "build/contracts/MyContract.json",
 ///     crate = ethcontract_rename,
+///     contract = MyContractInstance,
 ///     deployments {
 ///         4 => "0x000102030405060708090a0b0c0d0e0f10111213"
 ///         5777 => "0x0123456789012345678901234567890123456789"
@@ -62,8 +75,7 @@ pub fn contract(input: TokenStream) -> TokenStream {
 }
 
 fn expand(args: ContractArgs) -> Result<TokenStream2, Box<dyn Error>> {
-    let tokens = args.into_builder()?.generate()?.into_tokens();
-    Ok(tokens)
+    Ok(args.into_builder()?.generate()?.into_tokens())
 }
 
 /// Contract procedural macro arguments.

--- a/examples/etherscan.rs
+++ b/examples/etherscan.rs
@@ -1,0 +1,30 @@
+use ethcontract::web3::api::Web3;
+use ethcontract::web3::transports::Http;
+use std::env;
+
+ethcontract::contract!(
+    "etherscan:0x60fbbd1fb0076971e8060631b5dd895f55ad5ab7",
+    contract = Owl,
+);
+
+fn main() {
+    futures::executor::block_on(run());
+}
+
+async fn run() {
+    let infura_url = {
+        let project_id = env::var("INFURA_PROJECT_ID").expect("INFURA_PROJECT_ID is not set");
+        format!("https://mainnet.infura.io/v3/{}", project_id)
+    };
+
+    let (eloop, http) = Http::new(&infura_url).expect("transport failed");
+    eloop.into_remote();
+    let web3 = Web3::new(http);
+
+    let instance = Owl::deployed(&web3)
+        .await
+        .expect("locating deployed contract failed");
+    let symbol = instance.symbol().call().await.expect("get symbol failed");
+
+    println!("ERC20 token {}", symbol);
+}

--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -13,8 +13,10 @@ Code generation for type-safe bindings to Ethereum smart contracts.
 
 [dependencies]
 anyhow = "1.0"
+curl = "0.4"
 ethcontract-common = { version = "0.4.1", path = "../common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"
+url = "2.1"

--- a/generate/src/contract/common.rs
+++ b/generate/src/contract/common.rs
@@ -5,7 +5,7 @@ use quote::quote;
 
 pub(crate) fn expand(cx: &Context) -> TokenStream {
     let ethcontract = &cx.runtime_crate;
-    let artifact_path = &cx.artifact_path;
+    let artifact_json = &cx.artifact_json;
     let contract_name = &cx.contract_name;
 
     let doc_str = cx
@@ -26,15 +26,15 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
 
         #[allow(dead_code)]
         impl #contract_name {
-            /// Retrieves the truffle artifact used to generate the type safe API
-            /// for this contract.
+            /// Retrieves the truffle artifact used to generate the type safe
+            /// API for this contract.
             pub fn artifact() -> &'static #ethcontract::Artifact {
                 use #ethcontract::private::lazy_static;
                 use #ethcontract::Artifact;
 
                 lazy_static! {
                     pub static ref ARTIFACT: Artifact = {
-                        Artifact::from_json(include_str!(#artifact_path))
+                        Artifact::from_json(#artifact_json)
                             .expect("valid artifact JSON")
                     };
                 }

--- a/generate/src/source.rs
+++ b/generate/src/source.rs
@@ -1,0 +1,184 @@
+//! Module implements reading of contract artifacts from various sources.
+
+use crate::util;
+use anyhow::{anyhow, Context, Error, Result};
+use ethcontract_common::Address;
+use std::borrow::Cow;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use url::Url;
+
+/// A source of a Truffle artifact JSON.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Source {
+    /// A Truffle artifact located on the local file system.
+    Local(PathBuf),
+    /// An address of a mainnet contract that has been verified on Etherscan.io.
+    Etherscan(Address),
+}
+
+impl Source {
+    /// Parses an artifact source from a string.
+    ///
+    /// Contract artifacts can be retrieved from the local filesystem or online
+    /// from `etherscan.io`, this method parses artifact source URLs and accepts
+    /// the following:
+    /// - `relative/path/to/Contract.json`: a relative path to a truffle
+    ///   artifact JSON file. This relative path is rooted in the current
+    ///   working directory. To specify the root for relative paths, use
+    ///   `Source::with_root`.
+    /// - `/absolute/path/to/Contract.json` or
+    ///   `file:///absolute/path/to/Contract.json`: an absolute path or file URL
+    ///   to a truffle artifact JSON file.
+    /// - `etherscan:0xXX..XX` or `https://etherscan.io/address/0xXX..XX`: a
+    ///   address or URL of a verified contract on Etherscan.
+    pub fn parse<S>(source: S) -> Result<Self>
+    where
+        S: AsRef<str>,
+    {
+        let root = env::current_dir()?.canonicalize()?;
+        Source::with_root(root, source)
+    }
+
+    /// Parses an artifact source from a string and a specified root directory
+    /// for resolving relative paths. See `Source::with_root` for more details
+    /// on supported source strings.
+    pub fn with_root<P, S>(root: P, source: S) -> Result<Self>
+    where
+        P: AsRef<Path>,
+        S: AsRef<str>,
+    {
+        let base = Url::from_directory_path(root)
+            .map_err(|_| anyhow!("root path '{}' is not absolute"))?;
+        let url = base.join(source.as_ref())?;
+
+        match url.scheme() {
+            "file" => Ok(Source::local(url.path())),
+            "etherscan" => Source::etherscan(url.path()),
+            "http" | "https" => match url.host_str() {
+                Some("etherscan.io") => Source::etherscan(
+                    url.path()
+                        .rsplit('/')
+                        .next()
+                        .ok_or_else(|| anyhow!("HTTP URL does not have a path"))?,
+                ),
+                _ => Err(anyhow!("unsupported HTTP URL '{}'", url)),
+            },
+            _ => Err(anyhow!("unsupported URL '{}'", url)),
+        }
+    }
+
+    /// Creates a local filesystem source from a path string.
+    pub fn local<P>(path: P) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        Source::Local(path.as_ref().into())
+    }
+
+    /// Creates an Etherscan source from an address string.
+    pub fn etherscan<S>(address: S) -> Result<Self>
+    where
+        S: AsRef<str>,
+    {
+        let address =
+            util::parse_address(address).context("failed to parse address for Etherscan source")?;
+        Ok(Source::Etherscan(address))
+    }
+
+    /// Retrieves the source JSON of the artifact this will either read the JSON
+    /// from the file system or retrieve a contract ABI from the network
+    /// dependending on the source type.
+    pub fn artifact_json(&self) -> Result<String> {
+        match self {
+            Source::Local(path) => read_json(path),
+            Source::Etherscan(address) => get_etherscan_contract(*address),
+        }
+    }
+}
+
+impl FromStr for Source {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Source::parse(s)
+    }
+}
+
+/// Reads a Truffle artifact JSON file from the local filesystem.
+fn read_json(path: &Path) -> Result<String> {
+    let path = if path.is_relative() {
+        let absolute_path = path.canonicalize().with_context(|| {
+            format!(
+                "unable to canonicalize file from working dir {} with path {}",
+                env::current_dir()
+                    .map(|cwd| cwd.display().to_string())
+                    .unwrap_or_else(|err| format!("??? ({})", err)),
+                path.display(),
+            )
+        })?;
+        Cow::Owned(absolute_path)
+    } else {
+        Cow::Borrowed(path)
+    };
+
+    let json = fs::read_to_string(path).context("failed to read artifact JSON file")?;
+    Ok(json)
+}
+
+/// Retrieves a contract ABI from the Etherscan HTTP API and wraps it in an
+/// artifact JSON for compatibility with the code generation facilities.
+fn get_etherscan_contract(address: Address) -> Result<String> {
+    // NOTE: We do not retrieve the bytecode since deploying contracts with the
+    //   same bytecode is unreliable as the libraries have already linked and
+    //   probably don't reference anything when deploying on other networks.
+
+    let abi_url = format!(
+        "http://api.etherscan.io/api?module=contract&action=getabi&address={:?}&format=raw",
+        address,
+    );
+    let abi = util::http_get(&abi_url).context("failed to retrieve ABI from Etherscan.io")?;
+
+    // NOTE: Wrap the retrieved ABI in an empty contract, this is because
+    //   currently, the code generation infrastructure depends on having an
+    //   `Artifact` instance.
+    let json = format!(
+        r#"{{"abi":{},"networks":{{"1":{{"address":"{:?}"}}}}}}"#,
+        abi, address,
+    );
+
+    Ok(json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_source() {
+        let root = "/rooted";
+        for (url, expected) in &[
+            (
+                "relative/Contract.json",
+                Source::local("/rooted/relative/Contract.json"),
+            ),
+            (
+                "/absolute/Contract.json",
+                Source::local("/absolute/Contract.json"),
+            ),
+            (
+                "etherscan:0x0001020304050607080910111213141516171819",
+                Source::etherscan("0x0001020304050607080910111213141516171819").unwrap(),
+            ),
+            (
+                "https://etherscan.io/address/0x0001020304050607080910111213141516171819",
+                Source::etherscan("0x0001020304050607080910111213141516171819").unwrap(),
+            ),
+        ] {
+            let source = Source::with_root(root, url).unwrap();
+            assert_eq!(source, *expected);
+        }
+    }
+}

--- a/generate/src/util.rs
+++ b/generate/src/util.rs
@@ -1,13 +1,78 @@
+use anyhow::{anyhow, Result};
+use curl::easy::Easy;
+use ethcontract_common::Address;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
 
+/// Expands a identifier string into an token.
 pub fn ident(name: &str) -> Ident {
     Ident::new(name, Span::call_site())
 }
 
+/// Expands a doc string into an attribute token stream.
 pub fn expand_doc(s: &str) -> TokenStream {
     let doc = Literal::string(s);
     quote! {
         #[doc = #doc]
+    }
+}
+
+/// Parses the given address string
+pub fn parse_address<S>(address_str: S) -> Result<Address>
+where
+    S: AsRef<str>,
+{
+    let address_str = address_str.as_ref();
+    if !address_str.starts_with("0x") {
+        return Err(anyhow!("address must start with '0x'"));
+    }
+    Ok(address_str[2..].parse()?)
+}
+
+/// Perform an HTTP GET request and return the contents of the response.
+pub fn http_get(url: &str) -> Result<String> {
+    let mut buffer = Vec::new();
+    let mut handle = Easy::new();
+    handle.url(url)?;
+    {
+        let mut transfer = handle.transfer();
+        transfer.write_function(|data| {
+            buffer.extend_from_slice(data);
+            Ok(data.len())
+        })?;
+        transfer.perform()?;
+    }
+
+    let buffer = String::from_utf8(buffer)?;
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_address_missing_prefix() {
+        if parse_address("0000000000000000000000000000000000000000").is_ok() {
+            panic!("parsing address not starting with 0x should fail");
+        }
+    }
+
+    #[test]
+    fn parse_address_address_too_short() {
+        if parse_address("0x00000000000000").is_ok() {
+            panic!("parsing address not starting with 0x should fail");
+        }
+    }
+
+    #[test]
+    fn parse_address_ok() {
+        let expected = Address::from([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        ]);
+        assert_eq!(
+            parse_address("0x000102030405060708090a0b0c0d0e0f10111213").unwrap(),
+            expected
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,8 @@
 //! ```
 //!
 //! See [`contract!`](ethcontract::contract) proc macro documentation for more
-//! information on usage and parameters.
+//! information on usage and parameters as well on how to use contract ABI
+//! directly from Etherscan.
 
 #[cfg(test)]
 #[allow(missing_docs)]


### PR DESCRIPTION
This PR adds initial support for retrieving contract ABIs directly from Etherscan using the HTTP API.

Closes #119 

### Test Plan

A couple unit tests and a new example.