### PR TITLE
MockTransport proof of concept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,3 @@ serde_json = "1.0"
 thiserror = "1.0"
 web3 = "0.10"
 zeroize = "1.1"
-
-[dev-dependencies]
-mockall = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ serde_json = "1.0"
 thiserror = "1.0"
 web3 = "0.10"
 zeroize = "1.1"
+
+[dev-dependencies]
+mockall = "0.6"

--- a/src/test/prelude.rs
+++ b/src/test/prelude.rs
@@ -4,7 +4,7 @@ pub use crate::test::transport::MockTransport;
 pub use crate::test::transport::TestTransport;
 pub use crate::test::transport::TestTransport_;
 use futures::future::FutureExt;
-pub use mockall::predicate::*;
+pub use mockall::{predicate::*, Sequence};
 pub use serde_json::json;
 use std::future::Future;
 pub use web3::api::Web3;

--- a/src/test/prelude.rs
+++ b/src/test/prelude.rs
@@ -1,7 +1,10 @@
 //! Prelude module with common types used for unit tests.
 
+pub use crate::test::transport::MockTransport;
 pub use crate::test::transport::TestTransport;
+pub use crate::test::transport::TestTransport_;
 use futures::future::FutureExt;
+pub use mockall::predicate::*;
 pub use serde_json::json;
 use std::future::Future;
 pub use web3::api::Web3;

--- a/src/test/prelude.rs
+++ b/src/test/prelude.rs
@@ -1,10 +1,8 @@
 //! Prelude module with common types used for unit tests.
 
-pub use crate::test::transport::MockTransport;
 pub use crate::test::transport::TestTransport;
 pub use crate::test::transport::TestTransport_;
 use futures::future::FutureExt;
-pub use mockall::{predicate::*, Sequence};
 pub use serde_json::json;
 use std::future::Future;
 pub use web3::api::Web3;

--- a/src/test/transport.rs
+++ b/src/test/transport.rs
@@ -47,7 +47,7 @@ impl TestTransport_ {
             .push_back(RequestResponse {
                 request: Request {
                     method: method.into(),
-                    params: params.as_ref().into(),
+                    params: params.as_ref().to_vec(),
                 },
                 response,
             });

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -319,6 +319,35 @@ mod tests {
     }
 
     #[test]
+    fn tx_builder_estimate_gas_() {
+        let transport = TestTransport_::new();
+        let web3 = Web3::new(transport.clone());
+
+        let to = addr!("0x0123456789012345678901234567890123456789");
+
+        transport
+            .mock()
+            .expect_execute()
+            .with(
+                eq("eth_estimateGas"),
+                eq(vec![json!({
+                    "to": to,
+                    "value": "0x2a",
+                })]),
+            )
+            .times(1)
+            .return_const(web3::futures::future::ok(json!("0x42")));
+
+        let estimate_gas = TransactionBuilder::new(web3)
+            .to(to)
+            .value(42.into())
+            .estimate_gas();
+
+        let estimate_gas = estimate_gas.immediate().expect("success");
+        assert_eq!(estimate_gas, 0x42.into());
+    }
+
+    #[test]
     fn tx_send_local() {
         let mut transport = TestTransport::new();
         let web3 = Web3::new(transport.clone());

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -137,6 +137,23 @@ mod tests {
     }
 
     #[test]
+    fn dyn_transport_() {
+        let mut transport = TestTransport_::new();
+        let dyn_transport = DynTransport::new(transport.clone());
+
+        let method = "test";
+        let params = vec![json!(28)];
+        let response = Ok(json!(true));
+
+        // Assert that the underlying transport executes the request and returns
+        // the response.
+        transport.expect_request(method, &params, response.clone());
+        let response_ = dyn_transport.execute(method, params).wait();
+        assert_eq!(response, response_);
+        transport.assert_no_missing_requests();
+    }
+
+    #[test]
     #[allow(clippy::redundant_clone)]
     fn dyn_transport_does_not_double_wrap() {
         let transport = TestTransport::new();


### PR DESCRIPTION
This is how the TestTransport looks with mockall.
I have duplicated and converted one test to use the new transport (scroll up to see the original test) and kept the old `TestTransport` so that the project compiles.

Let me know if you think this is worthwhile before I start converting all of the tests @nlordell .