### PR TITLE
Bump to v0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -30,8 +30,8 @@ members = [
 ]
 
 [dependencies]
-ethcontract-common = { version = "0.4.1", path = "./common" }
-ethcontract-derive = { version = "0.4.1", path = "./derive", optional = true}
+ethcontract-common = { version = "0.4.2", path = "./common" }
+ethcontract-derive = { version = "0.4.2", path = "./derive", optional = true}
 futures = { version = "0.3", features = ["compat"] }
 futures-timer = "3.0"
 hex = "0.4"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ Proc macro for generating type-safe bindings to Ethereum smart contracts.
 proc-macro = true
 
 [dependencies]
-ethcontract-generate = { version = "0.4.1", path = "../generate" }
+ethcontract-generate = { version = "0.4.2", path = "../generate" }
 proc-macro2 = "1.0"
 syn = "1.0"
 

--- a/examples/generate/Cargo.toml
+++ b/examples/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples-generate"
-version = "0.4.1"
+version = "0.4.2"
 publish = false
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"

--- a/examples/truffle/package.json
+++ b/examples/truffle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethcontract-contracts",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": "true",
   "description": "Test contracts for ethcontract-rs runtime and proc macro.",
   "scripts": {

--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ Code generation for type-safe bindings to Ethereum smart contracts.
 
 [dependencies]
 anyhow = "1.0"
-ethcontract-common = { version = "0.4.1", path = "../common" }
+ethcontract-common = { version = "0.4.2", path = "../common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"


### PR DESCRIPTION
Adds the hash utilities and ABI extensions from #200 so contract method signatures and selectors can be computed.

This would be used by the metrics system in dex-services to track `eth_call` durations and payload sizes.


