### PR TITLE
`ethabi@11.0` to `ethabi@9.0` compatability layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
 ]
 
 [dependencies]
+ethabi_9_0 = { package = "ethabi", version = "9.0" }
 ethcontract-common = { version = "0.4.2", path = "./common" }
 ethcontract-derive = { version = "0.4.2", path = "./derive", optional = true}
 futures = { version = "0.3", features = ["compat"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ Common types for ethcontract-rs runtime and proc macro.
 """
 
 [dependencies]
-ethabi = "9.0"
+ethabi = "11.0"
 hex = "0.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/common/src/abiext.rs
+++ b/common/src/abiext.rs
@@ -5,28 +5,26 @@ use ethabi::Function;
 
 /// Extension trait for `ethabi::Function`.
 pub trait FunctionExt {
-    /// Compute the method signature in the standard ABI format.
-    fn signature(&self) -> String;
+    /// Compute the method signature in the standard ABI format. This does not
+    /// include the output types.
+    fn abi_signature(&self) -> String;
 
     /// Compute the Keccak256 function selector used by contract ABIs.
     fn selector(&self) -> [u8; 4];
 }
 
 impl FunctionExt for Function {
-    fn signature(&self) -> String {
-        format!(
-            "{}({})",
-            self.name,
-            self.inputs
-                .iter()
-                .map(|input| input.kind.to_string())
-                .collect::<Vec<_>>()
-                .join(","),
-        )
+    fn abi_signature(&self) -> String {
+        let mut full_signature = self.signature();
+        if let Some(colon) = full_signature.find(':') {
+            full_signature.truncate(colon);
+        }
+
+        full_signature
     }
 
     fn selector(&self) -> [u8; 4] {
-        hash::function_selector(self.signature())
+        hash::function_selector(self.abi_signature())
     }
 }
 
@@ -42,9 +40,17 @@ mod tests {
                 r#"{"name":"bar","inputs":[{"name":"a","type":"uint256"},{"name":"b","type":"bool"}],"outputs":[]}"#,
                 "bar(uint256,bool)",
             ),
+            (
+                r#"{"name":"baz","inputs":[{"name":"a","type":"uint256"}],"outputs":[{"name":"b","type":"bool"}]}"#,
+                "baz(uint256)",
+            ),
+            (
+                r#"{"name":"bax","inputs":[],"outputs":[{"name":"a","type":"uint256"},{"name":"b","type":"bool"}]}"#,
+                "bax()",
+            ),
         ] {
             let function: Function = serde_json::from_str(f).expect("invalid function JSON");
-            let signature = function.signature();
+            let signature = function.abi_signature();
             assert_eq!(signature, *expected);
         }
     }

--- a/generate/src/contract/types.rs
+++ b/generate/src/contract/types.rs
@@ -47,5 +47,12 @@ pub(crate) fn expand(cx: &Context, kind: &ParamType) -> Result<TokenStream> {
             let size = Literal::usize_unsuffixed(*n);
             Ok(quote! { [#inner; #size] })
         }
+        ParamType::Tuple(ts) => {
+            let inner = ts
+                .iter()
+                .map(|t| expand(cx, t))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(quote! { ( #( #inner ,)* ) })
+        }
     }
 }

--- a/generate/src/contract/types.rs
+++ b/generate/src/contract/types.rs
@@ -47,12 +47,8 @@ pub(crate) fn expand(cx: &Context, kind: &ParamType) -> Result<TokenStream> {
             let size = Literal::usize_unsuffixed(*n);
             Ok(quote! { [#inner; #size] })
         }
-        ParamType::Tuple(ts) => {
-            let inner = ts
-                .iter()
-                .map(|t| expand(cx, t))
-                .collect::<Result<Vec<_>>>()?;
-            Ok(quote! { ( #( #inner ,)* ) })
+        ParamType::Tuple(_) => {
+            Err(anyhow!("ABIEncoderV2 is currently not supported"))
         }
     }
 }

--- a/generate/src/contract/types.rs
+++ b/generate/src/contract/types.rs
@@ -47,8 +47,6 @@ pub(crate) fn expand(cx: &Context, kind: &ParamType) -> Result<TokenStream> {
             let size = Literal::usize_unsuffixed(*n);
             Ok(quote! { [#inner; #size] })
         }
-        ParamType::Tuple(_) => {
-            Err(anyhow!("ABIEncoderV2 is currently not supported"))
-        }
+        ParamType::Tuple(_) => Err(anyhow!("ABIEncoderV2 is currently not supported")),
     }
 }

--- a/src/abicompat.rs
+++ b/src/abicompat.rs
@@ -1,0 +1,100 @@
+//! This module implements compatibility conversions between `ethabi@9.0` which
+//! is used by `web3` and `ethabi@11.0` which is the latest. Unfortunately there
+//! are important fixes in the new version so this compatibility layer is
+//! necessary until a new `web3` version with the latest `ethabi` is released.
+
+use ethcontract_common::abi as ethabi_11_0;
+
+/// A compatibility trait implemented for converting between `ethabi@9.0` and
+/// `ethabi@11.0` types.
+pub trait AbiCompat {
+    /// The equivalent type from the other crate version.
+    type Compat;
+
+    /// Convert `self` into the its other crate version equivalent.
+    fn compat(self) -> Self::Compat;
+}
+
+impl AbiCompat for ethabi_9_0::Error {
+    type Compat = ethabi_11_0::Error;
+
+    fn compat(self) -> Self::Compat {
+        let ethabi_9_0::Error(kind, _) = self;
+        match kind {
+            ethabi_9_0::ErrorKind::Msg(err) => ethabi_11_0::Error::Other(err),
+            ethabi_9_0::ErrorKind::SerdeJson(err) => ethabi_11_0::Error::SerdeJson(err),
+            ethabi_9_0::ErrorKind::ParseInt(err) => ethabi_11_0::Error::ParseInt(err),
+            ethabi_9_0::ErrorKind::Utf8(err) => ethabi_11_0::Error::Utf8(err),
+            ethabi_9_0::ErrorKind::Hex(err) => ethabi_11_0::Error::Hex(err),
+            ethabi_9_0::ErrorKind::InvalidName(name) => ethabi_11_0::Error::InvalidName(name),
+            ethabi_9_0::ErrorKind::InvalidData => ethabi_11_0::Error::InvalidData,
+
+            // NOTE: There is a `__Nonexaustive` variant that should never be
+            // contructed, so the extra match arm is required here.
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl AbiCompat for ethabi_9_0::Token {
+    type Compat = ethabi_11_0::Token;
+
+    fn compat(self) -> Self::Compat {
+        match self {
+            ethabi_9_0::Token::Address(value) => ethabi_11_0::Token::Address(value),
+            ethabi_9_0::Token::FixedBytes(value) => ethabi_11_0::Token::FixedBytes(value),
+            ethabi_9_0::Token::Bytes(value) => ethabi_11_0::Token::Bytes(value),
+            ethabi_9_0::Token::Int(value) => ethabi_11_0::Token::Int(value),
+            ethabi_9_0::Token::Uint(value) => ethabi_11_0::Token::Uint(value),
+            ethabi_9_0::Token::Bool(value) => ethabi_11_0::Token::Bool(value),
+            ethabi_9_0::Token::String(value) => ethabi_11_0::Token::String(value),
+            ethabi_9_0::Token::FixedArray(value) => ethabi_11_0::Token::FixedArray(value.compat()),
+            ethabi_9_0::Token::Array(value) => ethabi_11_0::Token::Array(value.compat()),
+        }
+    }
+}
+
+impl AbiCompat for Vec<ethabi_9_0::Token> {
+    type Compat = Vec<ethabi_11_0::Token>;
+
+    fn compat(self) -> Self::Compat {
+        let mut tokens = Vec::with_capacity(self.len());
+        for token in self {
+            tokens.push(token.compat());
+        }
+        tokens
+    }
+}
+
+impl AbiCompat for ethabi_11_0::Token {
+    type Compat = Option<ethabi_9_0::Token>;
+
+    fn compat(self) -> Self::Compat {
+        match self {
+            ethabi_11_0::Token::Address(value) => Some(ethabi_9_0::Token::Address(value)),
+            ethabi_11_0::Token::FixedBytes(value) => Some(ethabi_9_0::Token::FixedBytes(value)),
+            ethabi_11_0::Token::Bytes(value) => Some(ethabi_9_0::Token::Bytes(value)),
+            ethabi_11_0::Token::Int(value) => Some(ethabi_9_0::Token::Int(value)),
+            ethabi_11_0::Token::Uint(value) => Some(ethabi_9_0::Token::Uint(value)),
+            ethabi_11_0::Token::Bool(value) => Some(ethabi_9_0::Token::Bool(value)),
+            ethabi_11_0::Token::String(value) => Some(ethabi_9_0::Token::String(value)),
+            ethabi_11_0::Token::FixedArray(value) => {
+                Some(ethabi_9_0::Token::FixedArray(value.compat()?))
+            }
+            ethabi_11_0::Token::Array(value) => Some(ethabi_9_0::Token::Array(value.compat()?)),
+            ethabi_11_0::Token::Tuple(_) => None,
+        }
+    }
+}
+
+impl AbiCompat for Vec<ethabi_11_0::Token> {
+    type Compat = Option<Vec<ethabi_9_0::Token>>;
+
+    fn compat(self) -> Self::Compat {
+        let mut tokens = Vec::with_capacity(self.len());
+        for token in self {
+            tokens.push(token.compat()?);
+        }
+        Some(tokens)
+    }
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -6,6 +6,7 @@ mod deploy;
 mod deployed;
 mod method;
 
+use crate::abicompat::AbiCompat;
 use crate::errors::{DeployError, LinkError};
 use ethcontract_common::abi::Result as AbiResult;
 use ethcontract_common::truffle::Network;
@@ -116,7 +117,7 @@ impl<T: Transport> Instance<T> {
         P: Tokenize,
     {
         let function = self.abi.function(name.as_ref())?;
-        let data = function.encode_input(&params.into_tokens())?;
+        let data = function.encode_input(&params.into_tokens().compat())?;
 
         // take ownership here as it greatly simplifies dealing with futures
         // lifetime as it would require the contract Instance to live until

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -1,10 +1,11 @@
 //! Implementation for creating instances for deployed contracts and deploying
 //! new contracts.
 
+use crate::abicompat::AbiCompat;
 use crate::errors::{DeployError, ExecutionError};
 use crate::transaction::send::SendFuture;
 use crate::transaction::{Account, GasPrice, TransactionBuilder, TransactionResult};
-use ethcontract_common::abi::ErrorKind as AbiErrorKind;
+use ethcontract_common::abi::Error as AbiError;
 use ethcontract_common::{Abi, Bytecode};
 use futures::ready;
 use pin_project::pin_project;
@@ -75,9 +76,9 @@ where
         }
 
         let code = bytecode.to_bytes()?;
-        let params = params.into_tokens();
+        let params = params.into_tokens().compat();
         let data = match (I::abi(&context).constructor(), params.is_empty()) {
-            (None, false) => return Err(AbiErrorKind::InvalidData.into()),
+            (None, false) => return Err(AbiError::InvalidData.into()),
             (None, true) => code,
             (Some(ctor), _) => Bytes(ctor.encode_input(code.0, &params)?),
         };

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,8 +6,7 @@ pub(crate) mod revert;
 mod web3contract;
 
 pub use self::web3contract::Web3ContractError;
-use ethcontract_common::abi::{Error as AbiError, ErrorKind as AbiErrorKind, Function};
-use ethcontract_common::FunctionExt;
+use ethcontract_common::abi::{Error as AbiError, Function};
 use secp256k1::Error as Secp256k1Error;
 use std::num::ParseIntError;
 use thiserror::Error;
@@ -39,7 +38,7 @@ pub enum DeployError {
 
     /// An error occured encoding deployment parameters with the contract ABI.
     #[error("error ABI ecoding deployment parameters: {0}")]
-    Abi(AbiErrorKind),
+    Abi(#[from] AbiError),
 
     /// Error executing contract deployment transaction.
     #[error("error executing contract deployment transaction: {0}")]
@@ -49,18 +48,6 @@ pub enum DeployError {
     /// address cannot be determined.
     #[error("contract deployment transaction pending: {0}")]
     Pending(H256),
-}
-
-impl From<AbiError> for DeployError {
-    fn from(err: AbiError) -> Self {
-        err.0.into()
-    }
-}
-
-impl From<AbiErrorKind> for DeployError {
-    fn from(err: AbiErrorKind) -> Self {
-        DeployError::Abi(err)
-    }
 }
 
 /// Error that can occur while executing a contract call or transaction.
@@ -99,6 +86,13 @@ pub enum ExecutionError {
     /// Transaction failure (e.g. out of gas or revert).
     #[error("transaction failed: {0:?}")]
     Failure(H256),
+
+    /// A call returned an unsupported token. This happens when using the
+    /// experimental `ABIEncoderV2` option.
+    ///
+    /// This is intended to be implemented in future version of `ethcontract`.
+    #[error("unsupported ABI token")]
+    UnsupportedToken,
 }
 
 impl From<Web3Error> for ExecutionError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@
 #[path = "test/macros.rs"]
 mod test_macros;
 
+mod abicompat;
 pub mod contract;
 mod conv;
 pub mod errors;


### PR DESCRIPTION
This PR decouples `ethcontract` `ethabi` version from `web3` one. This is the first step in implementing
- strategy for function name collision - this is needed as `ethabi@9.0` used by `web3` does not support multiple functions with the same name.
- ABIEncoderV2 support - `ethabi@11.0` is needed for the new `Token::Tuple` variant

Note that this will naturally go away once new `web3` versions are released but is needed for now.