### PR TITLE
Support method names with keyword identifiers

### DIFF
--- a/generate/src/contract/methods.rs
+++ b/generate/src/contract/methods.rs
@@ -36,7 +36,7 @@ pub(crate) fn expand(cx: &Context) -> Result<TokenStream> {
 fn expand_function(cx: &Context, function: &Function) -> Result<TokenStream> {
     let ethcontract = &cx.runtime_crate;
 
-    let name = util::ident(&function.name.to_snake_case());
+    let name = util::safe_ident(&function.name.to_snake_case());
     let name_str = Literal::string(&function.name);
 
     let signature = function_signature(&function);
@@ -100,8 +100,7 @@ fn input_name_to_ident(index: usize, name: &str) -> SynIdent {
         "" => format!("p{}", index),
         n => n.to_snake_case(),
     };
-    // Parsing keywords like `self` can fail, in this case we add an underscore.
-    syn::parse_str::<SynIdent>(&name_str).unwrap_or_else(|_| util::ident(&format!("{}_", name_str)))
+    util::safe_ident(&name_str)
 }
 
 fn expand_input_name(index: usize, name: &str) -> TokenStream {

--- a/generate/src/util.rs
+++ b/generate/src/util.rs
@@ -3,10 +3,19 @@ use curl::easy::Easy;
 use ethcontract_common::Address;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
+use syn::Ident as SynIdent;
 
 /// Expands a identifier string into an token.
 pub fn ident(name: &str) -> Ident {
     Ident::new(name, Span::call_site())
+}
+
+/// Expands an identifier string into a token and appending `_` if the
+/// identifier is for a reserved keyword.
+///
+/// Parsing keywords like `self` can fail, in this case we add an underscore.
+pub fn safe_ident(name: &str) -> Ident {
+    syn::parse_str::<SynIdent>(&name).unwrap_or_else(|_| ident(&format!("{}_", name)))
 }
 
 /// Expands a doc string into an attribute token stream.


### PR DESCRIPTION
This PR fixes a small issue where method names that were reserved Rust keywords were causing compile errors.

### Test Plan

CI