### PR TITLE
Add support for Etherscan API keys

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -34,6 +34,10 @@ use syn::{braced, parse_macro_input, Error as SynError, Ident, LitInt, LitStr, T
 /// ethcontract::contract!("https://etherscan.io/address/0x0001020304050607080910111213141516171819");
 /// ```
 ///
+/// Note that Etherscan rate-limits requests to their API, to avoid this an
+/// `ETHERSCAN_API_KEY` environment variable can be set. If it is, it will use
+/// that API key when retrieving the contract ABI.
+///
 /// Currently the proc macro accepts additional parameters to configure some
 /// aspects of the code generation. Specifically it accepts:
 /// - `crate`: The name of the `ethcontract` crate. This is useful if the crate

--- a/generate/src/source.rs
+++ b/generate/src/source.rs
@@ -135,9 +135,14 @@ fn get_etherscan_contract(address: Address) -> Result<String> {
     //   same bytecode is unreliable as the libraries have already linked and
     //   probably don't reference anything when deploying on other networks.
 
+    let api_key = env::var("ETHERSCAN_API_KEY")
+        .map(|key| format!("&apikey={}", key))
+        .unwrap_or_default();
+
     let abi_url = format!(
-        "http://api.etherscan.io/api?module=contract&action=getabi&address={:?}&format=raw",
-        address,
+        "http://api.etherscan.io/api\
+         ?module=contract&action=getabi&address={:?}&format=raw{}",
+        address, api_key,
     );
     let abi = util::http_get(&abi_url).context("failed to retrieve ABI from Etherscan.io")?;
 


### PR DESCRIPTION
Etherscan rate-limits requests. This PR implements reading `ETHERSCAN_API_KEY` environement variable to set the API key when retrieving the contract ABI for unlimited request madness.

### Test Plan

CI