### PR TITLE
Initial log stream implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
         - tail -f /dev/null | yarn --cwd examples/truffle start > /dev/null &
         - cargo run --example async
         - cargo run --example deployments
+        - cargo run --example events
         - cargo run --example etherscan
         - cargo run --package examples-generate
         - cargo run --example linked

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ yarn start
 ```
 
 - The `async` example deploys an ERC20 token and interacts with the contract
-  with various accounts. First start the local development server:
+  with various accounts.
   ```sh
   cargo run --example async
   ```
@@ -75,6 +75,12 @@ yarn start
   a separte testnet deployment wants to be used).
   ```sh
   cargo run --example deployments
+  ```
+
+- The `events` example illustrates how to listen to logs emitted by smart
+  contract events.
+  ```sh
+  cargo run --example events
   ```
 
 - The `generator` example (actually a separate crate to be able to have a build

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,48 @@
+use ethcontract::web3::api::Web3;
+use ethcontract::web3::transports::Http;
+use futures::compat::Future01CompatExt;
+use futures::join;
+use futures::stream::StreamExt;
+
+ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
+
+fn main() {
+    futures::executor::block_on(run());
+}
+
+async fn run() {
+    let (eloop, http) = Http::new("http://localhost:9545").expect("transport failed");
+    eloop.into_remote();
+    let web3 = Web3::new(http);
+
+    let accounts = web3
+        .eth()
+        .accounts()
+        .compat()
+        .await
+        .expect("get accounts failed");
+
+    let instance = RustCoin::builder(&web3)
+        .gas(4_712_388.into())
+        .deploy()
+        .await
+        .expect("deployment failed");
+    let mut transfers = instance
+        .instance
+        .event("Transfer")
+        .expect("transfer event not found");
+
+    join! {
+        async {
+            instance
+                .transfer(accounts[1], 1_000_000.into())
+                .send()
+                .await
+                .expect("transfer 0->1 failed");
+        },
+        async {
+            let log = transfers.next().await.expect("failed to get next transfer event");
+            println!("Received a transfer event: {:#?}", log);
+        },
+    };
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -163,7 +163,7 @@ impl<T: Transport> Instance<T> {
         Ok(LogStream::new(
             self.web3(),
             filter,
-            std::time::Duration::from_secs(7),
+            std::time::Duration::from_secs(1),
         ))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub mod contract;
 mod conv;
 pub mod errors;
 mod future;
+pub mod log;
 pub mod secret;
 pub mod sign;
 pub mod transaction;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,128 @@
+//! This module implements event builders and streams for retrieving events
+//! emitted by a contract.
+
+use crate::errors::ExecutionError;
+use futures::compat::{Compat01As03, Future01CompatExt, Stream01CompatExt};
+use futures::ready;
+use futures::stream::Stream;
+use pin_project::{pin_project, project};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use web3::api::{CreateFilter, FilterStream, Web3};
+use web3::types::{Filter, Log};
+use web3::Transport;
+
+/// A log stream that emits logs matching a certain filter.
+///
+/// Note that when creating a log stream that is only valid until a certain
+/// block number, the `Stream` implementation will currently remain in the
+/// pending state indefinitely.
+#[pin_project]
+pub struct LogStream<T: Transport> {
+    #[pin]
+    state: LogStreamState<T>,
+}
+
+/// The state of the log stream. It can either be creating a new log filter for
+/// retrieving new logs or streaming logs from the created filter.
+#[pin_project]
+enum LogStreamState<T: Transport> {
+    CreatingFilter(#[pin] CompatCreateFilter<T, Log>, Duration),
+    Streaming(#[pin] CompatFilterStream<T, Log>),
+}
+
+impl<T: Transport> LogStream<T> {
+    /// Create a new log stream from a given web3 provider, filter and polling
+    /// parameters.
+    pub fn new(web3: Web3<T>, filter: Filter, poll_interval: Duration) -> Self {
+        let create_filter = web3.eth_filter().create_logs_filter(filter).compat();
+        let state = LogStreamState::CreatingFilter(create_filter, poll_interval);
+        LogStream { state }
+    }
+}
+
+impl<T: Transport> Stream for LogStream<T> {
+    type Item = Result<Log, ExecutionError>;
+
+    #[project]
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        loop {
+            let mut state = self.as_mut().project().state;
+
+            #[project]
+            let next_state = match state.as_mut().project() {
+                LogStreamState::CreatingFilter(create_filter, poll_interval) => {
+                    let log_filter = match ready!(create_filter.poll(cx)) {
+                        Ok(log_filter) => log_filter,
+                        Err(err) => return Poll::Ready(Some(Err(err.into()))),
+                    };
+                    let stream = log_filter.stream(*poll_interval).compat();
+                    LogStreamState::Streaming(stream)
+                }
+                LogStreamState::Streaming(stream) => {
+                    return stream
+                        .poll_next(cx)
+                        .map(|result| result.map(|log| Ok(log?)))
+                }
+            };
+
+            *state = next_state;
+        }
+    }
+}
+
+/// A type alias for a stream that emits logs.
+type CompatFilterStream<T, R> = Compat01As03<FilterStream<T, R>>;
+
+/// A type alias for a future that resolves with the ID of a created log filter
+/// that can be queried in order to stream logs.
+type CompatCreateFilter<T, R> = Compat01As03<CreateFilter<T, R>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::prelude::*;
+    use futures::stream::StreamExt;
+    use serde_json::Value;
+    use web3::types::{Address, H256};
+
+    fn generate_log(kind: &str) -> Value {
+        json!({
+            "address": Address::zero(),
+            "topics": [],
+            "data": "0x",
+            "blockHash": H256::zero(),
+            "blockNumber": "0x0",
+            "transactionHash": H256::zero(),
+            "transactionIndex": "0x0",
+            "logIndex": "0x0",
+            "transactionLogIndex": "0x0",
+            "logType": kind,
+            "removed": false,
+        })
+    }
+
+    #[test]
+    fn log_stream_next_log() {
+        let mut transport = TestTransport::new();
+        let web3 = Web3::new(transport.clone());
+
+        // filter created
+        transport.add_response(json!("0xf0"));
+        // get logs filter
+        transport.add_response(json!([generate_log("awesome")]));
+
+        let log = LogStream::new(web3, Default::default(), Duration::from_secs(0))
+            .next()
+            .immediate()
+            .expect("log stream did not produce any logs")
+            .expect("failed to get log from log stream");
+
+        assert_eq!(log.log_type.as_deref(), Some("awesome"));
+        transport.assert_request("eth_newFilter", &[json!({})]);
+        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_no_more_requests();
+    }
+}


### PR DESCRIPTION
This is a first step in generating event streams for contracts, by creating a `futures v0.3` `Stream` that emits logs as they come in. 

Once this is merged the next steps will be to:
1. Create a builder for configuring the log stream (polling interval, timeouts, topic filters, etc.)
2. Adding some type-safety to the individual topics and data (so the topic data and log data can be decoded)
3. Generating event types
4. :rocket: Here we can add many features like filtering based on topic name instead of `topic0` and even creating filter builders (for and-ing and or-ing expressions)

### Test Plan

CI with new example and unit test.