### PR TITLE
[Easy] pin syn dependency to 1.0.12

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 ethcontract-generate = { version = "0.4.2", path = "../generate" }
 proc-macro2 = "1.0"
-syn = "1.0"
+syn = "1.0.12"
 
 [dev-dependencies]
 quote = "1.0"

--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -18,5 +18,5 @@ ethcontract-common = { version = "0.4.2", path = "../common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = "1.0.12"
 url = "2.1"


### PR DESCRIPTION
Earlier versions are missing the span function on ParseBuffer.

Cf: https://docs.rs/syn/1.0.12/syn/parse/struct.ParseBuffer.html#method.span
vs: https://docs.rs/syn/1.0.11/syn/parse/struct.ParseBuffer.html#method.span

Looks like they didn't take semantic versioning literally.

### Test Plan

CI (making sure I could build locally based on a Cargo.lock file that was working with v1.0.7)