### PR TITLE
Make DynTransport threadsafe

### DIFF
--- a/generate/src/contract/common.rs
+++ b/generate/src/contract/common.rs
@@ -52,7 +52,7 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
             ) -> Self
             where
                 F: #ethcontract::web3::futures::Future<Item = #ethcontract::json::Value, Error = #ethcontract::web3::Error> + Send + 'static,
-                T: #ethcontract::web3::Transport<Out = F> + 'static,
+                T: #ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 use #ethcontract::Instance;
                 use #ethcontract::transport::DynTransport;

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -50,7 +50,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
                 F: #ethcontract::web3::futures::Future<
                     Item = #ethcontract::json::Value,
                     Error = #ethcontract::web3::Error
-                > + Send + Sync + 'static,
+                > + Send + 'static,
                 T: #ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 use #ethcontract::contract::DeployedFuture;

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -50,8 +50,8 @@ fn expand_deployed(cx: &Context) -> TokenStream {
                 F: #ethcontract::web3::futures::Future<
                     Item = #ethcontract::json::Value,
                     Error = #ethcontract::web3::Error
-                > + Send + 'static,
-                T: #ethcontract::web3::Transport<Out = F> + 'static,
+                > + Send + Sync + 'static,
+                T: #ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 use #ethcontract::contract::DeployedFuture;
                 use #ethcontract::transport::DynTransport;
@@ -147,7 +147,7 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
             ) -> #ethcontract::DynDeployBuilder<Self>
             where
                 F: #ethcontract::web3::futures::Future<Item = #ethcontract::json::Value, Error = #ethcontract::web3::Error> + Send + 'static,
-                T: #ethcontract::web3::Transport<Out = F> + 'static,
+                T: #ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 use #ethcontract::DynTransport;
                 use #ethcontract::contract::DeployBuilder;

--- a/src/test/transport.rs
+++ b/src/test/transport.rs
@@ -2,9 +2,8 @@
 //! the `rust-web3` `TestTransport` type with some modifications.
 
 use jsonrpc_core::{Call, Value};
-use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 use web3::error::Error;
 use web3::futures::future::{self, FutureResult};
 use web3::helpers;
@@ -13,12 +12,17 @@ use web3::{RequestId, Transport};
 /// Type alias for request method and value pairs
 type Requests = Vec<(String, Vec<Value>)>;
 
+#[derive(Debug, Default)]
+struct Inner {
+    asserted: usize,
+    requests: Requests,
+    responses: VecDeque<Value>,
+}
+
 /// Test transport
 #[derive(Debug, Default, Clone)]
 pub struct TestTransport {
-    asserted: usize,
-    requests: Rc<RefCell<Requests>>,
-    responses: Rc<RefCell<VecDeque<Value>>>,
+    inner: Arc<Mutex<Inner>>,
 }
 
 impl Transport for TestTransport {
@@ -26,12 +30,14 @@ impl Transport for TestTransport {
 
     fn prepare(&self, method: &str, params: Vec<Value>) -> (RequestId, Call) {
         let request = helpers::build_request(1, method, params.clone());
-        self.requests.borrow_mut().push((method.into(), params));
-        (self.requests.borrow().len(), request)
+        let mut inner = self.inner.lock().unwrap();
+        inner.requests.push((method.into(), params));
+        (inner.requests.len(), request)
     }
 
     fn send(&self, id: RequestId, request: Call) -> Self::Out {
-        match self.responses.borrow_mut().pop_front() {
+        let mut inner = self.inner.lock().unwrap();
+        match inner.responses.pop_front() {
             Some(response) => future::ok(response),
             None => {
                 println!("Unexpected request (id: {:?}): {:?}", id, request);
@@ -49,32 +55,29 @@ impl TestTransport {
 
     /// Add a response to an eventual request.
     pub fn add_response(&mut self, value: Value) {
-        self.responses.borrow_mut().push_back(value);
+        let mut inner = self.inner.lock().unwrap();
+        inner.responses.push_back(value);
     }
 
     /// Assert that a request was made.
     pub fn assert_request(&mut self, method: &str, params: &[Value]) {
-        let idx = self.asserted;
-        self.asserted += 1;
+        let mut inner = self.inner.lock().unwrap();
+        let idx = inner.asserted;
+        inner.asserted += 1;
 
-        let (m, p) = self
-            .requests
-            .borrow()
-            .get(idx)
-            .expect("Expected result.")
-            .clone();
+        let (m, p) = inner.requests.get(idx).expect("Expected result.").clone();
         assert_eq!(&m, method);
         assert_eq!(&p[..], params);
     }
 
     /// Assert that there are no more pending requests.
     pub fn assert_no_more_requests(&self) {
-        let requests = self.requests.borrow();
+        let inner = self.inner.lock().unwrap();
         assert_eq!(
-            self.asserted,
-            requests.len(),
+            inner.asserted,
+            inner.requests.len(),
             "Expected no more requests, got: {:?}",
-            &requests[self.asserted..]
+            &inner.requests[inner.asserted..]
         );
     }
 }


### PR DESCRIPTION
`DynTransport` previously did not require `TransportBoxed` to be
threadsafe. This caused it to never be treated as threadsafe even when
the underlying transport was threadsafe.