### PR TITLE
Add module around generated code

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,7 +17,5 @@ proc-macro = true
 [dependencies]
 ethcontract-generate = { version = "0.5.0", path = "../generate" }
 proc-macro2 = "1.0"
-syn = "1.0.12"
-
-[dev-dependencies]
 quote = "1.0"
+syn = "1.0.12"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -61,7 +61,9 @@ use syn::{braced, parse_macro_input, Error as SynError, Ident, LitInt, LitStr, T
 ///
 /// Additionally, the ABI source can be preceeded by a visibility modifier such
 /// as `pub` or `pub(crate)`. This visibility modifier is applied to both the
-/// generated module and contract re-export.
+/// generated module and contract re-export. If no visibility modifier is
+/// provided, then none is used for the generated code as well, making the
+/// module and contract private to the scope where the macro was invoked.
 ///
 /// ```ignore
 /// ethcontract::contract!(

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -29,7 +29,7 @@ async fn run() {
         .await
         .expect("deployment failed");
     let mut transfers = instance
-        .instance
+        .raw_instance()
         .event::<_, (Address, Address, U256)>("Transfer")
         .expect("transfer event not found")
         .topic0(Topic::This(accounts[0])) // from

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -13,9 +13,11 @@ use crate::util;
 use crate::Args;
 use anyhow::{anyhow, Context as _, Result};
 use ethcontract_common::{Address, Artifact};
+use inflector::Inflector;
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
 use std::collections::HashMap;
+use syn::Visibility;
 
 /// Internal shared context for generating smart contract bindings.
 pub(crate) struct Context {
@@ -27,6 +29,12 @@ pub(crate) struct Context {
     /// it can be different if the crate was renamed in the Cargo manifest for
     /// example.
     runtime_crate: Ident,
+    /// The visibility for the generated module and re-exported contract type.
+    visibility: Visibility,
+    /// The name of the module as an identifier in which to place the contract
+    /// implementation. Note that the main contract type gets re-exported in the
+    /// root.
+    contract_mod: Ident,
     /// The contract name as an identifier.
     contract_name: Ident,
     /// Additional contract deployments.
@@ -55,27 +63,37 @@ impl Context {
         };
 
         let runtime_crate = util::ident(&args.runtime_crate_name);
-        let contract_name = {
-            let name = if let Some(name) = args.contract_name_override.as_ref() {
-                name
-            } else if !artifact.contract_name.is_empty() {
-                &artifact.contract_name
-            } else {
-                return Err(anyhow!(
-                    "contract artifact is missing a name, this can happen when \
+
+        let raw_contract_name = if let Some(name) = args.contract_name_override.as_ref() {
+            name
+        } else if !artifact.contract_name.is_empty() {
+            &artifact.contract_name
+        } else {
+            return Err(anyhow!(
+                "contract artifact is missing a name, this can happen when \
                      using a source that does not provide a contract name such \
                      as Etherscan; in this case the contract must be manually \
                      specified"
-                ));
-            };
-
-            util::ident(name)
+            ));
         };
+
+        let visibility = match args.visibility_modifier.as_ref() {
+            Some(vis) => syn::parse_str(vis)?,
+            None => Visibility::Inherited,
+        };
+        let contract_mod = if let Some(name) = args.contract_mod_override.as_ref() {
+            util::ident(name)
+        } else {
+            util::ident(&raw_contract_name.to_snake_case())
+        };
+        let contract_name = util::ident(raw_contract_name);
 
         Ok(Context {
             artifact_json,
             artifact,
             runtime_crate,
+            visibility,
+            contract_mod,
             contract_name,
             deployments: args.deployments,
         })
@@ -87,6 +105,8 @@ impl Context {
             artifact_json: Literal::string("{}"),
             artifact: Artifact::empty(),
             runtime_crate: util::ident("ethcontract"),
+            visibility: Visibility::Inherited,
+            contract_mod: util::ident("contract"),
             contract_name: util::ident("Contract"),
             deployments: HashMap::new(),
         }
@@ -102,13 +122,20 @@ pub(crate) fn expand(args: Args) -> Result<TokenStream> {
 }
 
 fn expand_contract(cx: &Context) -> Result<TokenStream> {
+    let vis = &cx.visibility;
+    let contract_mod = &cx.contract_mod;
+    let contract_name = &cx.contract_name;
+
     let common = common::expand(cx);
     let deployment = deployment::expand(cx)?;
     let methods = methods::expand(cx)?;
 
     Ok(quote! {
-        #common
-        #deployment
-        #methods
+        #vis mod #contract_mod {
+            #common
+            #deployment
+            #methods
+        }
+        #vis use self::#contract_mod::#contract_name;
     })
 }

--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -62,8 +62,6 @@ impl Context {
             (Literal::string(&artifact_json), artifact)
         };
 
-        let runtime_crate = util::ident(&args.runtime_crate_name);
-
         let raw_contract_name = if let Some(name) = args.contract_name_override.as_ref() {
             name
         } else if !artifact.contract_name.is_empty() {
@@ -71,12 +69,13 @@ impl Context {
         } else {
             return Err(anyhow!(
                 "contract artifact is missing a name, this can happen when \
-                     using a source that does not provide a contract name such \
-                     as Etherscan; in this case the contract must be manually \
-                     specified"
+                 using a source that does not provide a contract name such  as \
+                 Etherscan; in this case the contract must be manually \
+                 specified"
             ));
         };
 
+        let runtime_crate = util::ident(&args.runtime_crate_name);
         let visibility = match args.visibility_modifier.as_ref() {
             Some(vis) => syn::parse_str(vis)?,
             None => Visibility::Inherited,

--- a/generate/src/contract/common.rs
+++ b/generate/src/contract/common.rs
@@ -82,6 +82,18 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
             pub fn defaults_mut(&mut self) -> &mut #ethcontract::contract::MethodDefaults {
                 &mut self.instance.defaults
             }
+
+            /// Returns a reference to the raw runtime instance used by this
+            /// contract.
+            pub fn raw_instance(&self) -> &#ethcontract::DynInstance {
+                &self.instance
+            }
+
+            /// Returns a mutable reference to the raw runtime instance used by
+            /// this contract.
+            pub fn raw_instance_mut(&mut self) -> &mut #ethcontract::DynInstance {
+                &mut self.instance
+            }
         }
 
         impl std::fmt::Debug for #contract_name {

--- a/generate/src/contract/common.rs
+++ b/generate/src/contract/common.rs
@@ -88,12 +88,6 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
             pub fn raw_instance(&self) -> &#ethcontract::DynInstance {
                 &self.instance
             }
-
-            /// Returns a mutable reference to the raw runtime instance used by
-            /// this contract.
-            pub fn raw_instance_mut(&mut self) -> &mut #ethcontract::DynInstance {
-                &mut self.instance
-            }
         }
 
         impl std::fmt::Debug for #contract_name {

--- a/generate/src/lib.rs
+++ b/generate/src/lib.rs
@@ -26,6 +26,11 @@ pub(crate) struct Args {
     artifact_source: Source,
     /// The runtime crate name to use.
     runtime_crate_name: String,
+    /// The visibility modifier to use for the generated module and contract
+    /// re-export.
+    visibility_modifier: Option<String>,
+    /// Override the contract module name that contains the generated code.
+    contract_mod_override: Option<String>,
     /// Override the contract name to use for the generated type.
     contract_name_override: Option<String>,
     /// Manually specified deployed contract addresses.
@@ -39,6 +44,8 @@ impl Args {
         Args {
             artifact_source: source,
             runtime_crate_name: "ethcontract".to_owned(),
+            visibility_modifier: None,
+            contract_mod_override: None,
             contract_name_override: None,
             deployments: HashMap::new(),
         }
@@ -85,6 +92,25 @@ impl Builder {
         S: Into<String>,
     {
         self.args.runtime_crate_name = name.into();
+        self
+    }
+
+    /// Sets an optional visibility modifier for the generated module and
+    /// contract re-export.
+    pub fn with_visibility_modifier<S>(mut self, vis: Option<S>) -> Self
+    where
+        S: Into<String>,
+    {
+        self.args.visibility_modifier = vis.map(S::into);
+        self
+    }
+
+    /// Sets the optional contract module name override.
+    pub fn with_contract_mod_override<S>(mut self, name: Option<S>) -> Self
+    where
+        S: Into<String>,
+    {
+        self.args.contract_mod_override = name.map(S::into);
         self
     }
 


### PR DESCRIPTION
Add a module around implementation and specify visibility for generated contract code. This allows us to generate event types for contracts who have the same event names in the same scope. This also prevents implementation details (like private fields) from being accessible from outside the generated code.

### Test Plan

CI and unit tests