### PR TITLE
[Cleanup] Add macro for comparing expanded rust code

### DIFF
--- a/generate/src/contract.rs
+++ b/generate/src/contract.rs
@@ -80,9 +80,11 @@ impl Context {
             deployments: args.deployments,
         })
     }
+}
 
-    #[cfg(test)]
-    fn empty() -> Self {
+#[cfg(test)]
+impl Default for Context {
+    fn default() -> Self {
         Context {
             artifact_json: Literal::string("{}"),
             artifact: Artifact::empty(),

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -207,22 +207,19 @@ mod tests {
 
     #[test]
     fn expand_address_value() {
-        let cx = Context::empty();
+        assert_quote!(expand_address(&Context::default(), Address::zero()), {
+            ethcontract::Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        });
 
-        assert_eq!(
-            expand_address(&cx, Address::zero()).to_string(),
-            quote! {
-                ethcontract::Address::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-            }
-            .to_string(),
-        );
-
-        assert_eq!(
-            expand_address(&cx, "000102030405060708090a0b0c0d0e0f10111213".parse().unwrap()).to_string(),
-            quote! {
+        #[rustfmt::skip]
+        assert_quote!(
+            expand_address(
+                &Context::default(),
+                "000102030405060708090a0b0c0d0e0f10111213".parse().unwrap()
+            ),
+            {
                 ethcontract::Address::from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
-            }
-            .to_string(),
+            },
         );
     }
 }

--- a/generate/src/contract/methods.rs
+++ b/generate/src/contract/methods.rs
@@ -190,17 +190,17 @@ mod tests {
 
     #[test]
     fn expand_inputs_empty() {
-        assert_eq!(
-            expand_inputs(&Context::empty(), &[]).unwrap().to_string(),
-            ""
+        assert_quote!(
+            expand_inputs(&Context::default(), &[]).unwrap().to_string(),
+            {},
         );
     }
 
     #[test]
     fn expand_inputs_() {
-        assert_eq!(
+        assert_quote!(
             expand_inputs(
-                &Context::empty(),
+                &Context::default(),
                 &[
                     Param {
                         name: "a".to_string(),
@@ -212,43 +212,38 @@ mod tests {
                     },
                 ],
             )
-            .unwrap()
-            .to_string(),
-            ", a : bool , b : ethcontract :: Address"
+            .unwrap(),
+            { , a: bool, b: ethcontract::Address },
         );
     }
 
     #[test]
     fn expand_fn_outputs_empty() {
-        assert_eq!(
-            expand_fn_outputs(&Context::empty(), &[],)
-                .unwrap()
-                .to_string(),
-            "( )"
-        );
+        assert_quote!(expand_fn_outputs(&Context::default(), &[],).unwrap(), {
+            ()
+        });
     }
 
     #[test]
     fn expand_fn_outputs_single() {
-        assert_eq!(
+        assert_quote!(
             expand_fn_outputs(
-                &Context::empty(),
+                &Context::default(),
                 &[Param {
                     name: "a".to_string(),
                     kind: ParamType::Bool,
                 },],
             )
-            .unwrap()
-            .to_string(),
-            "bool"
+            .unwrap(),
+            { bool },
         );
     }
 
     #[test]
     fn expand_fn_outputs_muliple() {
-        assert_eq!(
+        assert_quote!(
             expand_fn_outputs(
-                &Context::empty(),
+                &Context::default(),
                 &[
                     Param {
                         name: "a".to_string(),
@@ -260,9 +255,8 @@ mod tests {
                     },
                 ],
             )
-            .unwrap()
-            .to_string(),
-            "( bool , ethcontract :: Address )"
+            .unwrap(),
+            { (bool, ethcontract::Address) },
         );
     }
 }

--- a/generate/src/lib.rs
+++ b/generate/src/lib.rs
@@ -4,6 +4,12 @@
 //! crate is intended to be used either indirectly with the `ethcontract`
 //! crate's `contract` procedural macro or directly from a build script.
 
+#[cfg(test)]
+#[allow(missing_docs)]
+#[macro_use]
+#[path = "test/macros.rs"]
+mod test_macros;
+
 mod contract;
 mod source;
 mod util;

--- a/generate/src/test/macros.rs
+++ b/generate/src/test/macros.rs
@@ -1,0 +1,10 @@
+/// Asserts the result of an expansion matches source output.
+///
+/// # Panics
+///
+/// If the expanded source does not match the quoted source.
+macro_rules! assert_quote {
+    ($ex:expr, { $($t:tt)* } $(,)?) => {
+        assert_eq!($ex.to_string(), quote::quote! { $($t)* }.to_string())
+    };
+}


### PR DESCRIPTION
This PR just cleans up the code generation tests a bit by adding a macro to compare quasi-quoted rust code instead of strings. This has the added benefit of being formattable by `rustfmt` and does not have require the sting to have precise spacing.

### Test Plan

Unit tests should still pass.