### PR TITLE
Use 32-bit method selector instead of function signature

### DIFF
--- a/common/src/abiext.rs
+++ b/common/src/abiext.rs
@@ -1,7 +1,7 @@
 //! This module implements extensions to the `ethabi` API.
 
 use crate::errors::ParseParamTypeError;
-use crate::hash;
+use crate::hash::{self, H32};
 use ethabi::{Event, Function, ParamType};
 use serde_json::json;
 
@@ -12,7 +12,7 @@ pub trait FunctionExt {
     fn abi_signature(&self) -> String;
 
     /// Compute the Keccak256 function selector used by contract ABIs.
-    fn selector(&self) -> [u8; 4];
+    fn selector(&self) -> H32;
 }
 
 impl FunctionExt for Function {
@@ -25,7 +25,7 @@ impl FunctionExt for Function {
         full_signature
     }
 
-    fn selector(&self) -> [u8; 4] {
+    fn selector(&self) -> H32 {
         hash::function_selector(self.abi_signature())
     }
 }

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -14,7 +14,10 @@ where
     output
 }
 
-/// A 32-byte hash prefix.
+/// A 32-bit prefix of a standard 256-bit Keccak hash.
+///
+/// This 32-bit prefix is generally used as the first 4 bytes of transaction
+/// data in order to select which Solidity method will be called.
 pub type H32 = [u8; 4];
 
 /// Calculate the function selector as per the contract ABI specification. This

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -14,15 +14,18 @@ where
     output
 }
 
+/// A 32-byte hash prefix.
+pub type H32 = [u8; 4];
+
 /// Calculate the function selector as per the contract ABI specification. This
 /// is definied as the first 4 bytes of the Keccak256 hash of the function
 /// signature.
-pub fn function_selector<S>(signature: S) -> [u8; 4]
+pub fn function_selector<S>(signature: S) -> H32
 where
     S: AsRef<str>,
 {
     let hash = keccak256(signature.as_ref());
-    let mut selector = [0u8; 4];
+    let mut selector = H32::default();
     selector.copy_from_slice(&hash[0..4]);
     selector
 }

--- a/src/errors/revert.rs
+++ b/src/errors/revert.rs
@@ -1,12 +1,12 @@
 //! Module implements decoding ABI encoded revert reasons.
 
 use ethcontract_common::abi::{self, ParamType};
-use ethcontract_common::hash;
+use ethcontract_common::hash::{self, H32};
 use lazy_static::lazy_static;
 
 lazy_static! {
     /// The ABI function selector for identifying encoded revert reasons.
-    static ref ERROR_SELECTOR: [u8; 4] = hash::function_selector("Error(string)");
+    static ref ERROR_SELECTOR: H32 = hash::function_selector("Error(string)");
 }
 
 /// Decodes an ABI encoded revert reason. Returns `Some(reason)` when the ABI


### PR DESCRIPTION
Use 32-bit method selector instead of function signature for method identification in the runtime.

### Test Plan

CI