### PR TITLE
Generate code for streaming all contract events

### DIFF
--- a/generate/src/contract/events.rs
+++ b/generate/src/contract/events.rs
@@ -400,7 +400,7 @@ fn expand_event_enum(cx: &Context) -> TokenStream {
             .map(|event| {
                 let struct_name = expand_struct_name(&event);
                 quote! {
-                    #struct_name(self::events::#struct_name)
+                    #struct_name(self::event_data::#struct_name)
                 }
             })
             .collect::<Vec<_>>()
@@ -705,8 +705,8 @@ mod tests {
         assert_quote!(expand_event_enum(&context), {
             /// A contract event.
             pub enum Event {
-                Bar(self::events::Bar),
-                Foo(self::events::Foo),
+                Bar(self::event_data::Bar),
+                Foo(self::event_data::Foo),
             }
         });
     }

--- a/src/contract/event.rs
+++ b/src/contract/event.rs
@@ -97,6 +97,20 @@ impl<T> Event<T> {
             EventData::Added(_) => None,
         }
     }
+
+    /// Maps the inner data of an event into some other data.
+    pub fn map<U, F>(self, f: F) -> Event<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        Event {
+            data: match self.data {
+                EventData::Added(inner) => EventData::Added(f(inner)),
+                EventData::Removed(inner) => EventData::Removed(f(inner)),
+            },
+            meta: self.meta,
+        }
+    }
 }
 
 impl EventMetadata {
@@ -292,7 +306,7 @@ pub trait ParseLog: Sized {
     fn parse_log(log: RawLog) -> Result<Self, ExecutionError>;
 }
 
-/// Raw log transaction data.
+/// Raw log topics and data for a contract event.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RawLog {
     /// The raw 32-byte topics.


### PR DESCRIPTION
This PR generates code for creating streaming all events from a contract where the event data is an enum whose variants are each of the possible contract events.

### Test Plan

New unit test. I will implement a larger example (and potential fixes) as a separate PR.