### PR TITLE
Include past logs in the stream

### DIFF
--- a/src/contract/event.rs
+++ b/src/contract/event.rs
@@ -55,7 +55,7 @@ pub struct EventMetadata {
     /// The index of the log in the block.
     pub log_index: usize,
     /// The log index in the transaction this log belongs to.
-    pub transaction_log_index: usize,
+    pub transaction_log_index: Option<usize>, // TODO: this wasn't available in my test
     /// The log type. Note that this property is non-standard but is supported
     /// by Parity nodes.
     pub log_type: Option<String>,
@@ -121,7 +121,7 @@ impl EventMetadata {
             transaction_hash: log.transaction_hash?,
             transaction_index: log.transaction_index?.as_usize(),
             log_index: log.log_index?.as_usize(),
-            transaction_log_index: log.transaction_log_index?.as_usize(),
+            transaction_log_index: log.transaction_log_index.map(|i| i.as_usize()),
             log_type: log.log_type.clone(),
         })
     }


### PR DESCRIPTION
No need to review yet.

Calling `stream` on the filter translates to a `eth_getFilterChanges`
rpc call which does not include past logs from before the filter's
creation.

This is just the first version I got working to be able to test the event based orderbook. I am sharing it because @nlordell and I talked about it.