### PR TITLE
Returned boxed transaction receipt on failure

### DIFF
--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -200,9 +200,7 @@ where
         let address = match tx.contract_address {
             Some(address) => address,
             None => {
-                return Poll::Ready(Err(DeployError::Tx(ExecutionError::Failure(
-                    tx.transaction_hash,
-                ))));
+                return Poll::Ready(Err(DeployError::Tx(ExecutionError::Failure(Box::new(tx)))));
             }
         };
         let transaction_hash = tx.transaction_hash;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,7 @@ use std::num::ParseIntError;
 use thiserror::Error;
 use uint::FromDecStrErr;
 use web3::error::Error as Web3Error;
-use web3::types::H256;
+use web3::types::{TransactionReceipt, H256};
 
 /// Error that can occur while locating a deployed contract.
 #[derive(Debug, Error)]
@@ -85,8 +85,8 @@ pub enum ExecutionError {
     ConfirmTimeout,
 
     /// Transaction failure (e.g. out of gas or revert).
-    #[error("transaction failed: {0:?}")]
-    Failure(H256),
+    #[error("transaction failed: {:?}", .0.transaction_hash)]
+    Failure(Box<TransactionReceipt>),
 
     /// A call returned an unsupported token. This happens when using the
     /// experimental `ABIEncoderV2` option.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -458,7 +458,7 @@ mod tests {
 
         assert!(
             match &result {
-                Err(ExecutionError::Failure(ref hash)) if *hash == tx_hash => true,
+                Err(ExecutionError::Failure(ref tx)) if tx.transaction_hash == tx_hash => true,
                 _ => false,
             },
             "expected transaction failure with hash {} but got {:?}",

--- a/src/transaction/send.rs
+++ b/src/transaction/send.rs
@@ -108,7 +108,7 @@ impl<T: Transport> Future for SendFuture<T> {
                         let tx = result?;
                         match tx.status {
                             Some(U64([1])) => Ok(TransactionResult::Receipt(tx)),
-                            _ => Err(ExecutionError::Failure(tx.transaction_hash)),
+                            _ => Err(ExecutionError::Failure(Box::new(tx))),
                         }
                     })
                 }


### PR DESCRIPTION
:point_up: This allows callers to inspect the transaction receipt when it failed because of a revert or out of gas (for example). 

Note that the transaction receipt is boxed - this is because it it a rather sizeable struct and it doesn't make sense for the error types, and therefore the result types, to be so large. Not boxing also produces a clippy lint warning.

### Test Plan

Nothing to do! This error variant was always created from a transaction receipt anyway so there is no new logic.