### PR TITLE
Get past logs

### DIFF
--- a/generate/src/contract/events.rs
+++ b/generate/src/contract/events.rs
@@ -292,14 +292,23 @@ fn expand_builder_type(event: &Event) -> Result<TokenStream> {
                 self
             }
 
-            /// The polling interval. This is used as the interval between consecutive
-            /// `eth_getFilterChanges` calls to get filter updates.
+            /// The polling interval. This is used as the interval between
+            /// consecutive `eth_getFilterChanges` calls to get filter updates.
             pub fn poll_interval(mut self, value: std::time::Duration) -> Self {
                 self.0 = (self.0).poll_interval(value);
                 self
             }
 
             #topic_filters
+
+            /// Returns a future that resolves with a collection of all existing
+            /// logs matching the builder parameters.
+            pub fn query(self) -> self::ethcontract::contract::QueryFuture<
+                self::ethcontract::dyns::DynTransport,
+                self::event_data::#event_name,
+            > {
+                (self.0).query().expect("generated event query")
+            }
 
             /// Creates an event stream from the current event builder.
             pub fn stream(self) -> self::ethcontract::contract::EventStream<

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -24,8 +24,8 @@ use web3::Transport;
 pub use self::deploy::{Deploy, DeployBuilder, DeployFuture};
 pub use self::deployed::{DeployedFuture, FromNetwork};
 pub use self::event::{
-    AllEventsBuilder, Event, EventBuilder, EventData, EventMetadata, EventStream, ParseLog, RawLog,
-    Topic, DEFAULT_POLL_INTERVAL,
+    AllEventsBuilder, Event, EventBuilder, EventData, EventMetadata, EventStream, ParseLog,
+    QueryAllFuture, QueryFuture, RawLog, Topic, DEFAULT_POLL_INTERVAL,
 };
 pub use self::method::{
     CallFuture, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture, ViewMethodBuilder,

--- a/src/contract/event.rs
+++ b/src/contract/event.rs
@@ -3,13 +3,16 @@
 
 use crate::abicompat::AbiCompat;
 use crate::errors::{EventError, ExecutionError};
+use crate::future::CompatCallFuture;
 use crate::log::LogStream;
 pub use ethcontract_common::abi::Topic;
 use ethcontract_common::abi::{
     Event as AbiEvent, RawLog as AbiRawLog, RawTopicFilter, Token, TopicFilter,
 };
+use futures::compat::Future01CompatExt;
 use futures::stream::Stream;
 use pin_project::{pin_project, project};
+use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -62,6 +65,27 @@ pub struct EventMetadata {
 }
 
 impl<T> Event<T> {
+    /// Creates an event from a log given a mapping function.
+    fn from_log<E, F>(log: Log, f: F) -> Result<Self, E>
+    where
+        F: FnOnce(RawLog) -> Result<T, E>,
+    {
+        let meta = EventMetadata::from_log(&log);
+        let data = {
+            let removed = log.removed == Some(true);
+            let raw = RawLog::from(log);
+            let inner_data = f(raw)?;
+
+            if removed {
+                EventData::Removed(inner_data)
+            } else {
+                EventData::Added(inner_data)
+            }
+        };
+
+        Ok(Event { data, meta })
+    }
+
     /// Get a reference the underlying event data regardless of whether the
     /// event was added or removed.
     pub fn inner_data(&self) -> &T {
@@ -219,6 +243,12 @@ impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
         self
     }
 
+    /// Returns a future that resolves with a collection of all existing logs
+    /// matching the builder parameters.
+    pub fn query(self) -> Result<QueryFuture<T, E>, EventError> {
+        QueryFuture::from_builder(self)
+    }
+
     /// Creates an event stream from the current event builder.
     pub fn stream(self) -> Result<EventStream<T, E>, EventError> {
         EventStream::from_builder(self)
@@ -231,6 +261,59 @@ where
     P: Tokenizable,
 {
     topic.map(|parameter| parameter.into_token().compat())
+}
+
+/// A future for querying events based on a log filter.
+#[must_use = "futures do nothing unless you await or poll them"]
+#[pin_project]
+pub struct QueryFuture<T: Transport, E: Detokenize> {
+    event: AbiEvent,
+    #[pin]
+    inner: CompatCallFuture<T, Vec<Log>>,
+    _event: PhantomData<E>,
+}
+
+impl<T: Transport, E: Detokenize> QueryFuture<T, E> {
+    /// Create a new query future from event builder parameters.
+    pub fn from_builder(builder: EventBuilder<T, E>) -> Result<Self, EventError> {
+        let event = builder.event;
+
+        let web3 = builder.web3;
+        let filter = {
+            let abi_filter = event
+                .filter(builder.topics)
+                .map_err(|err| EventError::new(&event, err))?;
+            builder.filter.topic_filter(abi_filter.compat()).build()
+        };
+
+        let inner = web3.eth().logs(filter).compat();
+
+        Ok(QueryFuture {
+            event,
+            inner,
+            _event: PhantomData,
+        })
+    }
+}
+
+impl<T: Transport, E: Detokenize> Future for QueryFuture<T, E> {
+    type Output = Result<Vec<Event<E>>, EventError>;
+
+    #[project]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        #[project]
+        let QueryFuture { event, inner, .. } = self.project();
+
+        inner
+            .poll(cx)
+            .map(|logs| {
+                logs?
+                    .into_iter()
+                    .map(|log| Event::from_log(log, |raw| raw.decode(event)))
+                    .collect::<Result<Vec<_>, ExecutionError>>()
+            })
+            .map(|result| result.map_err(|err| EventError::new(&event, err)))
+    }
 }
 
 /// An event stream that emits events matching a builder.
@@ -277,24 +360,8 @@ impl<T: Transport, E: Detokenize> Stream for EventStream<T, E> {
         #[project]
         let EventStream { event, inner, .. } = self.project();
         inner.poll_next(cx).map(|next| {
-            next.map(|log| {
-                let log = log?;
-
-                let meta = EventMetadata::from_log(&log);
-                let removed = log.removed == Some(true);
-
-                let raw_log = RawLog::from(log);
-                let inner_data = raw_log.decode(event)?;
-
-                let data = if removed {
-                    EventData::Removed(inner_data)
-                } else {
-                    EventData::Added(inner_data)
-                };
-
-                Ok(Event { data, meta })
-            })
-            .map(|next: Result<_, ExecutionError>| next.map_err(|err| EventError::new(&event, err)))
+            next.map(|log| Event::from_log(log?, |raw| raw.decode(event)))
+                .map(|next| next.map_err(|err| EventError::new(&event, err)))
         })
     }
 }
@@ -432,9 +499,52 @@ impl<T: Transport, E: ParseLog> AllEventsBuilder<T, E> {
         self
     }
 
+    /// Returns a future that resolves into a collection of events matching the
+    /// event builder's parameters.
+    pub fn query(self) -> QueryAllFuture<T, E> {
+        QueryAllFuture::from_builder(self)
+    }
+
     /// Creates an event stream from the current event builder.
     pub fn stream(self) -> AllEventsStream<T, E> {
         AllEventsStream::from_builder(self)
+    }
+}
+
+/// A future for querying all contract events based on a log filter.
+#[must_use = "futures do nothing unless you await or poll them"]
+#[pin_project]
+pub struct QueryAllFuture<T: Transport, E: ParseLog> {
+    #[pin]
+    inner: CompatCallFuture<T, Vec<Log>>,
+    _event: PhantomData<E>,
+}
+
+impl<T: Transport, E: ParseLog> QueryAllFuture<T, E> {
+    /// Create a new query future from event builder parameters.
+    pub fn from_builder(builder: AllEventsBuilder<T, E>) -> Self {
+        let web3 = builder.web3;
+        let filter = builder.filter.topic_filter(builder.topics.compat()).build();
+
+        let inner = web3.eth().logs(filter).compat();
+
+        QueryAllFuture {
+            inner,
+            _event: PhantomData,
+        }
+    }
+}
+
+impl<T: Transport, E: ParseLog> Future for QueryAllFuture<T, E> {
+    type Output = Result<Vec<Event<E>>, ExecutionError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        self.project().inner.poll(cx).map(|logs| {
+            logs?
+                .into_iter()
+                .map(|log| Event::from_log(log, E::parse_log))
+                .collect::<Result<Vec<_>, ExecutionError>>()
+        })
     }
 }
 
@@ -467,25 +577,10 @@ impl<T: Transport, E: ParseLog> Stream for AllEventsStream<T, E> {
     type Item = Result<Event<E>, ExecutionError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        self.project().inner.poll_next(cx).map(|next| {
-            next.map(|log| {
-                let log = log?;
-
-                let meta = EventMetadata::from_log(&log);
-                let removed = log.removed == Some(true);
-
-                let raw_log = RawLog::from(log);
-                let inner_data = E::parse_log(raw_log)?;
-
-                let data = if removed {
-                    EventData::Removed(inner_data)
-                } else {
-                    EventData::Added(inner_data)
-                };
-
-                Ok(Event { data, meta })
-            })
-        })
+        self.project()
+            .inner
+            .poll_next(cx)
+            .map(|next| next.map(|log| Event::from_log(log?, E::parse_log)))
     }
 }
 


### PR DESCRIPTION
This PR adds a new `query` method on event builders to query a collection of past logs without setting up a filter.

Note that this PR is in **addition** to #263, as this is a way of querying past logs all at once. Streaming past logs is still relevant and should be implemented separately. 

### Test Plan
 
Added unit tests