### PR TITLE
Event ABI examples

### DIFF
--- a/examples/abi.rs
+++ b/examples/abi.rs
@@ -19,8 +19,13 @@ async fn run() {
         .expect("contract deployment failure");
     println!("Using contract at {:?}", instance.address());
 
+    calls(&instance).await;
+    events(&instance).await;
+}
+
+async fn calls(instance: &AbiTypes) {
     macro_rules! debug_call {
-        (instance . $call:ident ()) => {{
+        (instance. $call:ident ()) => {{
             let value = instance
                 .$call()
                 .call()
@@ -58,6 +63,28 @@ async fn run() {
 
     debug_call!(instance.get_array());
     debug_call!(instance.get_fixed_array());
+}
+
+async fn events(instance: &AbiTypes) {
+    macro_rules! debug_events {
+        (instance.events(). $events:ident ()) => {{
+            let events = instance
+                .events()
+                .$events()
+                .query()
+                .await
+                .expect(concat!(stringify!($call), " failed"));
+            println!("{}()\n  ⏎ {:?}", stringify!($call), events,)
+        }};
+    }
+
+    instance
+        .emit_values()
+        .send()
+        .await
+        .expect("failed to emit value events");
+
+    debug_events!(instance.events().value_uint());
 }
 
 fn type_name_of<T>(_: &T) -> &'static str {

--- a/examples/abi.rs
+++ b/examples/abi.rs
@@ -95,6 +95,7 @@ async fn events(instance: &AbiTypes) {
     debug_events!(instance.events().value_bool());
     debug_events!(instance.events().value_bytes());
     debug_events!(instance.events().value_array());
+    debug_events!(instance.events().value_indexed());
 
     let all_events = instance
         .all_events()

--- a/examples/truffle/contracts/AbiTypes.sol
+++ b/examples/truffle/contracts/AbiTypes.sol
@@ -84,4 +84,23 @@ contract AbiTypes {
     }
     return buf;
   }
+
+  event ValueUint(uint8, uint16, uint32, uint64, uint128, uint256 indexed value);
+  event ValueInt(int8, int16, int32, int64, int128, int256 indexed value);
+
+  event ValueBool(bool);
+
+  event ValueBytes(string indexed id, bytes, bytes6, address whoami);
+  event ValueArray(uint64[] indexed, int32[3] indexed);
+
+  event Values(bytes32 indexed block, address sender) anonymous;
+
+  function emitValues() public {
+    emit ValueUint(getU8(), getU16(), getU32(), getU64(), getU128(), getU256());
+    emit ValueInt(getI8(), getI16(), getI32(), getI64(), getI128(), getI256());
+    emit ValueBool(getBool());
+    emit ValueBytes(getString(), getBytes(), getFixedBytes(), getAddress());
+    emit ValueArray(getArray(), getFixedArray());
+    emit Values(blockhash(block.number - 1), msg.sender);
+  }
 }

--- a/examples/truffle/contracts/AbiTypes.sol
+++ b/examples/truffle/contracts/AbiTypes.sol
@@ -90,8 +90,8 @@ contract AbiTypes {
 
   event ValueBool(bool);
 
-  event ValueBytes(string indexed id, bytes, bytes6, address whoami);
-  event ValueArray(uint64[] indexed, int32[3] indexed);
+  event ValueBytes(string id, bytes, bytes6, address whoami);
+  event ValueArray(uint64[], int32[3]);
 
   event Values(bytes32 indexed block, address sender) anonymous;
 

--- a/examples/truffle/contracts/AbiTypes.sol
+++ b/examples/truffle/contracts/AbiTypes.sol
@@ -93,6 +93,8 @@ contract AbiTypes {
   event ValueBytes(string id, bytes, bytes6, address whoami);
   event ValueArray(uint64[], int32[3]);
 
+  event ValueIndexed(string indexed, uint64[] indexed);
+
   event Values(bytes32 indexed block, address sender) anonymous;
 
   function emitValues() public {
@@ -101,6 +103,7 @@ contract AbiTypes {
     emit ValueBool(getBool());
     emit ValueBytes(getString(), getBytes(), getFixedBytes(), getAddress());
     emit ValueArray(getArray(), getFixedArray());
+    emit ValueIndexed(getString(), getArray());
     emit Values(blockhash(block.number - 1), msg.sender);
   }
 }

--- a/generate/src/contract/events.rs
+++ b/generate/src/contract/events.rs
@@ -435,7 +435,7 @@ fn expand_event_parse_log(cx: &Context) -> TokenStream {
 
                 let name = Literal::string(&event.name);
                 let decode_event = quote! {
-                    log.decode(
+                    log.clone().decode(
                         &Contract::artifact()
                             .abi
                             .event(#name)
@@ -765,7 +765,7 @@ mod tests {
                         .copied()
                         .map(|topic| match topic {
                             #foo_signature => Ok(Event::Foo(
-                                log.decode(
+                                log.clone().decode(
                                     &Contract::artifact()
                                         .abi
                                         .event("Foo")
@@ -779,7 +779,7 @@ mod tests {
                         return Ok(data);
                     }
 
-                    if let Ok(data) = log.decode(
+                    if let Ok(data) = log.clone().decode(
                         &Contract::artifact()
                             .abi
                             .event("Bar")

--- a/generate/src/contract/events.rs
+++ b/generate/src/contract/events.rs
@@ -1,7 +1,7 @@
 use crate::contract::{types, Context};
 use crate::util;
 use anyhow::Result;
-use ethcontract_common::abi::{Event, EventParam, Hash};
+use ethcontract_common::abi::{Event, EventParam, Hash, ParamType};
 use ethcontract_common::abiext::EventExt;
 use inflector::Inflector;
 use proc_macro2::{Literal, TokenStream};
@@ -133,7 +133,8 @@ fn expand_params(event: &Event) -> Result<Vec<(TokenStream, TokenStream)>> {
         .map(|(i, input)| {
             // NOTE: Events can contain nameless values.
             let name = util::expand_input_name(i, &input.name);
-            let ty = types::expand(&input.kind)?;
+            let ty = expand_input_type(&input)?;
+
             Ok((name, ty))
         })
         .collect()
@@ -349,7 +350,7 @@ fn expand_builder_topic_filter(topic_index: usize, param: &EventParam) -> Result
     } else {
         util::safe_ident(&param.name.to_snake_case())
     };
-    let ty = types::expand(&param.kind)?;
+    let ty = expand_input_type(&param)?;
 
     Ok(quote! {
         #doc
@@ -512,6 +513,24 @@ fn expand_event_parse_log(cx: &Context) -> TokenStream {
             }
         }
     }
+}
+
+/// Expands an event property type.
+///
+/// Note that this is slightly different than an expanding a Solidity type as
+/// complex types like arrays and strings get emited as hashes when they are
+/// indexed.
+fn expand_input_type(input: &EventParam) -> Result<TokenStream> {
+    Ok(match (&input.kind, input.indexed) {
+        (ParamType::Array(..), true)
+        | (ParamType::Bytes, true)
+        | (ParamType::FixedArray(..), true)
+        | (ParamType::String, true)
+        | (ParamType::Tuple(..), true) => {
+            quote! { self::ethcontract::H256 }
+        }
+        (kind, _) => types::expand(kind)?,
+    })
 }
 
 /// Expands a 256-bit `Hash` into a literal representation that can be used with


### PR DESCRIPTION
This PR extends the ABI example to include events will all kinds of Solidity types to illustrate how they work with the generated event types.

Additionally, this fixes an issue with the anonymous event code as well as an issue with the generated event types when a complex type is indexed.

### Test Plan

This is a test!