### PR TITLE
Allow methods with empty return type to be callable.

### DIFF
--- a/examples/abi.rs
+++ b/examples/abi.rs
@@ -40,6 +40,7 @@ async fn calls(instance: &AbiTypes) {
         }};
     }
 
+    debug_call!(instance.get_void());
     debug_call!(instance.get_u8());
     debug_call!(instance.get_u16());
     debug_call!(instance.get_u32());

--- a/examples/truffle/contracts/AbiTypes.sol
+++ b/examples/truffle/contracts/AbiTypes.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.5.0;
  * @dev Contract to illustract support for various Solidity types.
  */
 contract AbiTypes {
+  function getVoid() public pure {}
+
   function getU8() public view returns (uint8) {
     return uint8(this.getU256() & 0xff);
   }

--- a/generate/src/contract/methods.rs
+++ b/generate/src/contract/methods.rs
@@ -144,7 +144,7 @@ pub(crate) fn expand_inputs_call_arg(inputs: &[Param]) -> TokenStream {
 
 fn expand_fn_outputs(outputs: &[Param]) -> Result<TokenStream> {
     match outputs.len() {
-        0 => Ok(quote! { () }),
+        0 => Ok(quote! { self::ethcontract::Void }),
         1 => types::expand(&outputs[0].kind),
         _ => {
             let types = outputs
@@ -169,7 +169,9 @@ fn expand_fallback(cx: &Context) -> TokenStream {
             impl Contract {
                 /// Returns a method builder to setup a call to a smart
                 /// contract's fallback function.
-                pub fn fallback<D>(&self, data: D) -> self::ethcontract::dyns::DynMethodBuilder<()>
+                pub fn fallback<D>(&self, data: D) -> self::ethcontract::dyns::DynMethodBuilder<
+                    self::ethcontract::Void,
+                >
                 where
                     D: Into<Vec<u8>>,
                 {

--- a/generate/src/contract/methods.rs
+++ b/generate/src/contract/methods.rs
@@ -218,7 +218,9 @@ mod tests {
 
     #[test]
     fn expand_fn_outputs_empty() {
-        assert_quote!(expand_fn_outputs(&[],).unwrap(), { () });
+        assert_quote!(expand_fn_outputs(&[],).unwrap(), {
+            self::ethcontract::Void
+        });
     }
 
     #[test]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -186,7 +186,6 @@ impl<T: Transport> Instance<T> {
     pub fn view_method<P, R>(&self, signature: H32, params: P) -> AbiResult<ViewMethodBuilder<T, R>>
     where
         P: Tokenize,
-        R: Detokenize,
     {
         Ok(self.method(signature, params)?.view())
     }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -28,7 +28,8 @@ pub use self::event::{
     QueryAllFuture, QueryFuture, RawLog, Topic, DEFAULT_POLL_INTERVAL,
 };
 pub use self::method::{
-    CallFuture, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture, ViewMethodBuilder,
+    CallFuture, Detokenizable, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture,
+    ViewMethodBuilder, Void,
 };
 
 /// Represents a contract instance at an address. Provides methods for
@@ -159,6 +160,7 @@ impl<T: Transport> Instance<T> {
     pub fn method<P, R>(&self, signature: H32, params: P) -> AbiResult<MethodBuilder<T, R>>
     where
         P: Tokenize,
+        R: Detokenizable,
     {
         let signature = signature.as_ref();
         let function = self
@@ -186,6 +188,7 @@ impl<T: Transport> Instance<T> {
     pub fn view_method<P, R>(&self, signature: H32, params: P) -> AbiResult<ViewMethodBuilder<T, R>>
     where
         P: Tokenize,
+        R: Detokenizable,
     {
         Ok(self.method(signature, params)?.view())
     }
@@ -195,7 +198,7 @@ impl<T: Transport> Instance<T> {
     ///
     /// This method will error if the ABI does not contain an entry for a
     /// fallback function.
-    pub fn fallback<D>(&self, data: D) -> AbiResult<MethodBuilder<T, ()>>
+    pub fn fallback<D>(&self, data: D) -> AbiResult<MethodBuilder<T, Void>>
     where
         D: Into<Vec<u8>>,
     {

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -130,6 +130,12 @@ impl<T: Transport, R> MethodBuilder<T, R> {
     pub fn send(self) -> MethodSendFuture<T> {
         MethodFuture::new(self.function, self.tx.send())
     }
+
+    /// Demotes a `MethodBuilder` into a `ViewMethodBuilder` which has a more
+    /// restricted API and cannot actually send transactions.
+    pub fn view(self) -> ViewMethodBuilder<T, R> {
+        ViewMethodBuilder::from_method(self)
+    }
 }
 
 /// Future that wraps an inner transaction execution future to add method
@@ -169,12 +175,6 @@ where
 pub type MethodSendFuture<T> = MethodFuture<SendFuture<T>>;
 
 impl<T: Transport, R: Detokenize> MethodBuilder<T, R> {
-    /// Demotes a `MethodBuilder` into a `ViewMethodBuilder` which has a more
-    /// restricted API and cannot actually send transactions.
-    pub fn view(self) -> ViewMethodBuilder<T, R> {
-        ViewMethodBuilder::from_method(self)
-    }
-
     /// Call a contract method. Contract calls do not modify the blockchain and
     /// as such do not require gas or signing. Note that doing a call with a
     /// block number requires first demoting the `MethodBuilder` into a

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -188,14 +188,14 @@ impl<T: Transport, R: Detokenize> MethodBuilder<T, R> {
 /// directly send transactions and is for read only method calls.
 #[derive(Debug, Clone)]
 #[must_use = "view methods do nothing unless you `.call()` them"]
-pub struct ViewMethodBuilder<T: Transport, R: Detokenize> {
+pub struct ViewMethodBuilder<T: Transport, R> {
     /// method parameters
     pub m: MethodBuilder<T, R>,
     /// optional block number
     pub block: Option<BlockNumber>,
 }
 
-impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
+impl<T: Transport, R> ViewMethodBuilder<T, R> {
     /// Create a new `ViewMethodBuilder` by demoting a `MethodBuilder`.
     pub fn from_method(method: MethodBuilder<T, R>) -> Self {
         ViewMethodBuilder {
@@ -243,7 +243,9 @@ impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
         self.block = Some(value);
         self
     }
+}
 
+impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
     /// Call a contract method. Contract calls do not modify the blockchain and
     /// as such do not require gas or signing.
     pub fn call(self) -> CallFuture<T, R> {

--- a/src/contract/method.rs
+++ b/src/contract/method.rs
@@ -7,7 +7,7 @@ use crate::errors::{revert, ExecutionError, MethodError};
 use crate::future::CompatCallFuture;
 use crate::transaction::send::SendFuture;
 use crate::transaction::{Account, GasPrice, TransactionBuilder};
-use ethcontract_common::abi::Function;
+use ethcontract_common::abi::{Function, Token};
 use futures::compat::Future01CompatExt;
 use pin_project::pin_project;
 use std::future::Future;
@@ -16,8 +16,63 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use web3::api::Web3;
 use web3::contract::tokens::Detokenize;
+use web3::contract::Error as Web3ContractError;
 use web3::types::{Address, BlockNumber, Bytes, CallRequest, U256};
 use web3::Transport;
+
+/// A void type to represent methods with empty return types.
+///
+/// This is used to work around the fact that `(): !Detokenize`.
+pub struct Void(());
+
+/// Represents a type can detokenize a result.
+pub trait Detokenizable {
+    /// The output that this type detokenizes into.
+    type Output;
+
+    /// Returns true if this is an empty type.
+    fn is_empty() -> bool;
+
+    /// Create an instance of `Output` by decoding tokens.
+    fn from_tokens(tokens: Vec<Token>) -> Result<Self::Output, ExecutionError>;
+}
+
+impl Detokenizable for Void {
+    type Output = ();
+
+    fn is_empty() -> bool {
+        true
+    }
+
+    fn from_tokens(tokens: Vec<Token>) -> Result<Self::Output, ExecutionError> {
+        if !tokens.is_empty() {
+            return Err(Web3ContractError::InvalidOutputType(format!(
+                "Expected no elements, got tokens: {:?}",
+                tokens
+            ))
+            .into());
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: Detokenize> Detokenizable for T {
+    type Output = Self;
+
+    fn is_empty() -> bool {
+        false
+    }
+
+    fn from_tokens(tokens: Vec<Token>) -> Result<Self::Output, ExecutionError> {
+        let tokens = match tokens.compat() {
+            Some(tokens) => tokens,
+            None => return Err(ExecutionError::UnsupportedToken),
+        };
+        let result = <T as Detokenize>::from_tokens(tokens)?;
+        Ok(result)
+    }
+}
 
 /// Default options to be applied to `MethodBuilder` or `ViewMethodBuilder`.
 #[derive(Clone, Debug, Default)]
@@ -35,7 +90,7 @@ pub struct MethodDefaults {
 /// transactions. This is useful when dealing with view functions.
 #[derive(Debug, Clone)]
 #[must_use = "methods do nothing unless you `.call()` or `.send()` them"]
-pub struct MethodBuilder<T: Transport, R> {
+pub struct MethodBuilder<T: Transport, R: Detokenizable> {
     web3: Web3<T>,
     function: Function,
     /// transaction parameters
@@ -43,7 +98,7 @@ pub struct MethodBuilder<T: Transport, R> {
     _result: PhantomData<R>,
 }
 
-impl<T: Transport> MethodBuilder<T, ()> {
+impl<T: Transport> MethodBuilder<T, Void> {
     /// Creates a new builder for a transaction invoking the fallback method.
     pub fn fallback(web3: Web3<T>, address: Address, data: Bytes) -> Self {
         // NOTE: We create a fake `Function` entry for the fallback method. This
@@ -58,7 +113,7 @@ impl<T: Transport> MethodBuilder<T, ()> {
     }
 }
 
-impl<T: Transport, R> MethodBuilder<T, R> {
+impl<T: Transport, R: Detokenizable> MethodBuilder<T, R> {
     /// Creates a new builder for a transaction.
     pub fn new(web3: Web3<T>, function: Function, address: Address, data: Bytes) -> Self {
         MethodBuilder {
@@ -136,6 +191,14 @@ impl<T: Transport, R> MethodBuilder<T, R> {
     pub fn view(self) -> ViewMethodBuilder<T, R> {
         ViewMethodBuilder::from_method(self)
     }
+
+    /// Call a contract method. Contract calls do not modify the blockchain and
+    /// as such do not require gas or signing. Note that doing a call with a
+    /// block number requires first demoting the `MethodBuilder` into a
+    /// `ViewMethodBuilder` and setting the block number for the call.
+    pub fn call(self) -> CallFuture<T, R> {
+        self.view().call()
+    }
 }
 
 /// Future that wraps an inner transaction execution future to add method
@@ -174,28 +237,18 @@ where
 /// A type alias for a `MethodFuture` wrapped `SendFuture`.
 pub type MethodSendFuture<T> = MethodFuture<SendFuture<T>>;
 
-impl<T: Transport, R: Detokenize> MethodBuilder<T, R> {
-    /// Call a contract method. Contract calls do not modify the blockchain and
-    /// as such do not require gas or signing. Note that doing a call with a
-    /// block number requires first demoting the `MethodBuilder` into a
-    /// `ViewMethodBuilder` and setting the block number for the call.
-    pub fn call(self) -> CallFuture<T, R> {
-        self.view().call()
-    }
-}
-
 /// Data used for building a contract method call. The view method builder can't
 /// directly send transactions and is for read only method calls.
 #[derive(Debug, Clone)]
 #[must_use = "view methods do nothing unless you `.call()` them"]
-pub struct ViewMethodBuilder<T: Transport, R> {
+pub struct ViewMethodBuilder<T: Transport, R: Detokenizable> {
     /// method parameters
     pub m: MethodBuilder<T, R>,
     /// optional block number
     pub block: Option<BlockNumber>,
 }
 
-impl<T: Transport, R> ViewMethodBuilder<T, R> {
+impl<T: Transport, R: Detokenizable> ViewMethodBuilder<T, R> {
     /// Create a new `ViewMethodBuilder` by demoting a `MethodBuilder`.
     pub fn from_method(method: MethodBuilder<T, R>) -> Self {
         ViewMethodBuilder {
@@ -245,7 +298,7 @@ impl<T: Transport, R> ViewMethodBuilder<T, R> {
     }
 }
 
-impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
+impl<T: Transport, R: Detokenizable> ViewMethodBuilder<T, R> {
     /// Call a contract method. Contract calls do not modify the blockchain and
     /// as such do not require gas or signing.
     pub fn call(self) -> CallFuture<T, R> {
@@ -257,14 +310,14 @@ impl<T: Transport, R: Detokenize> ViewMethodBuilder<T, R> {
 /// the call completes.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[pin_project]
-pub struct CallFuture<T: Transport, R: Detokenize> {
+pub struct CallFuture<T: Transport, R: Detokenizable> {
     function: Function,
     #[pin]
     call: CompatCallFuture<T, Bytes>,
     _result: PhantomData<Box<R>>,
 }
 
-impl<T: Transport, R: Detokenize> CallFuture<T, R> {
+impl<T: Transport, R: Detokenizable> CallFuture<T, R> {
     /// Construct a new `CallFuture` from a `ViewMethodBuilder`.
     fn from_builder(builder: ViewMethodBuilder<T, R>) -> Self {
         CallFuture {
@@ -294,15 +347,15 @@ impl<T: Transport, R: Detokenize> CallFuture<T, R> {
     }
 }
 
-impl<T: Transport, R: Detokenize> Future for CallFuture<T, R> {
-    type Output = Result<R, MethodError>;
+impl<T: Transport, R: Detokenizable> Future for CallFuture<T, R> {
+    type Output = Result<R::Output, MethodError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let mut this = self.project();
         this.call.as_mut().poll(cx).map(|result| {
             result
                 .map_err(ExecutionError::from)
-                .and_then(|bytes| decode_geth_call_result(&this.function, bytes.0))
+                .and_then(|bytes| decode_geth_call_result::<R>(&this.function, bytes.0))
                 .map_err(|err| MethodError::new(&this.function, err))
         })
     }
@@ -316,24 +369,21 @@ impl<T: Transport, R: Detokenize> Future for CallFuture<T, R> {
 /// encode this information in a JSON RPC error. On a revert or invalid opcode,
 /// the result is `0x` (empty data), while on a revert with message, it is an
 /// ABI encoded `Error(string)` function call data.
-fn decode_geth_call_result<R: Detokenize>(
+fn decode_geth_call_result<R: Detokenizable>(
     function: &Function,
     bytes: Vec<u8>,
-) -> Result<R, ExecutionError> {
+) -> Result<R::Output, ExecutionError> {
     if let Some(reason) = revert::decode_reason(&bytes) {
         // This is an encoded revert message from Geth nodes.
         Err(ExecutionError::Revert(Some(reason)))
-    } else if bytes.is_empty() {
+    } else if bytes.is_empty() && !R::is_empty() {
         // Geth does this on `revert()` without a message and `invalid()`,
         // just treat them all as `invalid()` as generally contracts revert
         // with messages.
         Err(ExecutionError::InvalidOpcode)
     } else {
         // just a plain ol' regular result, try and decode it
-        let tokens = match function.decode_output(&bytes)?.compat() {
-            Some(tokens) => tokens,
-            None => return Err(ExecutionError::UnsupportedToken),
-        };
+        let tokens = function.decode_output(&bytes)?;
         let result = R::from_tokens(tokens)?;
         Ok(result)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub mod prelude {
     //! A prelude module for importing commonly used types when interacting with
     //! generated contracts.
 
-    pub use crate::contract::{Event, EventData, EventMetadata, RawLog, Topic};
+    pub use crate::contract::{Event, EventData, EventMetadata, RawLog, Topic, Void};
     pub use crate::int::I256;
     pub use crate::secret::{Password, PrivateKey};
     pub use crate::transaction::{Account, GasPrice};


### PR DESCRIPTION
This PR allows callable methods have an empty return type to be callable.

### Test Plan

Added empty return type view method to example.