### PR TITLE
Increase timeout between cargo publish

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -56,7 +56,9 @@ function cargo_publish {
 	# NOTE(nlordell): For some reason, the next publish fails on not being able
 	#   to find the new version; maybe it takes a second for crates.io to update
 	#   its index
-	sleep 10
+	if [[ "$1" != "." ]]; then
+		sleep 20
+	fi
 }
 
 cargo_publish common


### PR DESCRIPTION
Last couple of auto-publishes we were getting issues where the previously published crate in the workspace was not available on crates.io yet (see [here](https://travis-ci.org/github/gnosis/ethcontract-rs/jobs/671936777#L898) and [here](https://travis-ci.org/github/gnosis/ethcontract-rs/jobs/675275151#L734)).

This PR just increases the timeout to make this less likely to happen.

### Test Plan

See if next time we deploy this error doesn't happen.