### PR TITLE
[Easy] Use LTS node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
     tar -C bin -xvf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz --wildcards '*/sccache' --strip 1
     popd
   - $SCCACHE --version
-  - nvm install stable && nvm alias default stable
+  - nvm install --lts && nvm alias default 'lts/*'
   - node --version
   - npm install -g yarn@latest
   - yarn --version

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ found in the `ethcontract-generate` [README](generate/README.md).
 ## Running the Examples
 
 In order to run local examples you will additionally need:
-- NodeJS
+- NodeJS LTS
 - Yarn
 
 For all examples, the smart contracts must first be built:


### PR DESCRIPTION
Use latest LTS node instead of latest stable as node 14 was just released and is causing issues with the truffle project on CI.