### PR TITLE
Query past events paginated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Cargo.lock
 
 node_modules/
 examples/*/build/
+
+.idea

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ yarn start
 - The `deployments` example illustrates how the `deployments` parameter can be
   specified when generating a contract with the `ethcontract::contract!` macro.
   This can be useful for specifying addresses in testing environments that are
-  deterministic but either not included, or inacurate in the artifact's
+  deterministic but either not included, or inaccurate in the artifact's
   `networks` property (when for example the contract is developed upstream, but
-  a separte testnet deployment wants to be used).
+  a separate testnet deployment wants to be used).
   ```sh
   cargo run --example deployments
   ```
@@ -96,7 +96,7 @@ yarn start
   cargo run --package examples-generate
   ```
 
-- The `linked` example deploys a library and a contract that links to it and
+- The `linked` example deploys a library and a contract that links to it then
   makes a method call.
   ```sh
   cargo run --example linked
@@ -116,10 +116,11 @@ export INFURA_PROJECT_ID="Infura project ID"
 cargo run --example rinkeby
 ```
 
-### Sources Example
+### Mainnet Examples
 
+### Sources: 
 This example generates contract bindings from online sources:
-- A verfied contract on Etherscan
+- A verified contract on Etherscan
 - An npmjs contract
 
 It also queries some contract state with Infura. Running this example requires
@@ -129,6 +130,16 @@ the example by environment variables:
 ```sh
 export INFURA_PROJECT_ID="Infura project ID"
 cargo run --example sources
+```
+
+#### Past Events:
+
+This example retrieves the entire event history of token OWL contract and prints
+the total number of events since deployment.
+ 
+```sh
+export INFURA_PROJECT_ID="Infura project ID"
+`cargo run --example past_events`
 ```
 
 ## Sample Contracts Documentation

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ cargo run --example sources
 
 This example retrieves the entire event history of token OWL contract and prints
 the total number of events since deployment.
+
+Note the special handling of the `tokenOWLProxy` contract and how it is cast into
+a `tokenOWL` instance using Contract's `with_transaction` feature.
  
 ```sh
 export INFURA_PROJECT_ID="Infura project ID"

--- a/README.md
+++ b/README.md
@@ -61,46 +61,64 @@ cd examples/truffle
 yarn start
 ```
 
-- The `abi` example deploys a simple contract and performs various `eth_call`s
-  to illustrate how Solidity types are mapped to Rust types by `ethcontract`.
-  ```sh
-  cargo run --example abi
-  ```
+#### ABI:
 
-- The `async` example deploys an ERC20 token and interacts with the contract
-  with various accounts.
-  ```sh
-  cargo run --example async
-  ```
+The `abi` example deploys a simple contract and performs various `eth_call`s
+to illustrate how Solidity types are mapped to Rust types by `ethcontract`.
 
-- The `deployments` example illustrates how the `deployments` parameter can be
-  specified when generating a contract with the `ethcontract::contract!` macro.
-  This can be useful for specifying addresses in testing environments that are
-  deterministic but either not included, or inaccurate in the artifact's
-  `networks` property (when for example the contract is developed upstream, but
-  a separate testnet deployment wants to be used).
-  ```sh
-  cargo run --example deployments
-  ```
+```sh
+cargo run --example abi
+```
 
-- The `events` example illustrates how to listen to logs emitted by smart
-  contract events.
-  ```sh
-  cargo run --example events
-  ```
+#### Async/Await:
 
-- The `generator` example (actually a separate crate to be able to have a build
-  script) demonstrates how the generator API can be used for creating type-safe
-  bindings to a smart contract with a `build.rs` build script.
-  ```sh
-  cargo run --package examples-generate
-  ```
+The `async` example deploys an ERC20 token and interacts with the contract
+with various accounts.
 
-- The `linked` example deploys a library and a contract that links to it then
-  makes a method call.
-  ```sh
-  cargo run --example linked
-  ```
+```sh
+cargo run --example async
+```
+
+#### Manual Deployments:
+
+The `deployments` example illustrates how the `deployments` parameter can be
+specified when generating a contract with the `ethcontract::contract!` macro.
+This can be useful for specifying addresses in testing environments that are
+deterministic but either not included, or inaccurate in the artifact's
+`networks` property (when for example the contract is developed upstream, but
+a separate testnet deployment wants to be used).
+
+```sh
+cargo run --example deployments
+```
+
+#### Events:
+
+The `events` example illustrates how to listen to logs emitted by smart
+contract events.
+
+```sh
+cargo run --example events
+```
+
+#### Generator API (with `build.rs` script):
+
+The `generator` example (actually a separate crate to be able to have a build
+script) demonstrates how the generator API can be used for creating type-safe
+bindings to a smart contract with a `build.rs` build script.
+
+```sh
+cargo run --package examples-generate
+```
+
+#### Contract Linking:
+
+The `linked` example deploys a library and a contract that links to it then
+makes a method call.
+
+```sh
+cargo run --example linked
+```
 
 ### Rinkeby Example
 
@@ -118,7 +136,8 @@ cargo run --example rinkeby
 
 ### Mainnet Examples
 
-### Sources: 
+#### Sources:
+
 This example generates contract bindings from online sources:
 - A verified contract on Etherscan
 - An npmjs contract
@@ -136,10 +155,10 @@ cargo run --example sources
 
 This example retrieves the entire event history of token OWL contract and prints
 the total number of events since deployment.
- 
+
 ```sh
 export INFURA_PROJECT_ID="Infura project ID"
-`cargo run --example past_events`
+cargo run --example past_events
 ```
 
 ## Sample Contracts Documentation

--- a/examples/past_events.rs
+++ b/examples/past_events.rs
@@ -1,0 +1,39 @@
+use ethcontract::prelude::*;
+use std::env;
+
+ethcontract::contract!("npm:@gnosis.pm/owl-token@3.1.0/build/contracts/TokenOWLProxy.json");
+ethcontract::contract!("npm:@gnosis.pm/owl-token@3.1.0/build/contracts/TokenOWL.json");
+
+fn main() {
+    futures::executor::block_on(run());
+}
+
+async fn run() {
+    let infura_url = {
+        let project_id = env::var("INFURA_PROJECT_ID").expect("INFURA_PROJECT_ID is not set");
+        format!("https://mainnet.infura.io/v3/{}", project_id)
+    };
+
+    let (eloop, http) = Http::new(&infura_url).expect("transport failed");
+    eloop.into_remote();
+    let web3 = Web3::new(http);
+
+    let owl_proxy = TokenOWLProxy::deployed(&web3)
+        .await
+        .expect("locating deployed contract failed");
+
+    // Casting proxy token into actual token
+    let owl_token =
+        TokenOWL::with_transaction(&web3, owl_proxy.address(), owl_proxy.transaction_hash());
+    println!("Using OWL token at {:?}", owl_token.address());
+    println!("Retrieving all past events (this could take a while)...");
+    let event_history = owl_token
+        .all_events()
+        .query_past_events_paginated()
+        .await
+        .expect("Couldn't retrieve event history");
+    println!(
+        "Total number of events emitted by OWL token {:}",
+        event_history.len()
+    );
+}

--- a/generate/src/contract/events.rs
+++ b/generate/src/contract/events.rs
@@ -399,6 +399,7 @@ fn expand_all_events(cx: &Context) -> TokenStream {
                 self::ethcontract::dyns::DynAllEventsBuilder::new(
                     self.raw_instance().web3(),
                     self.address(),
+                    self.transaction_hash(),
                 )
             }
         }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -235,7 +235,7 @@ impl<T: Transport> Instance<T> {
     /// Returns a log stream that emits a log for every new event emitted after
     /// the stream was created for this contract instance.
     pub fn all_events(&self) -> AllEventsBuilder<T, RawLog> {
-        AllEventsBuilder::new(self.web3(), self.address())
+        AllEventsBuilder::new(self.web3(), self.address(), self.transaction_hash())
     }
 }
 

--- a/src/contract/event.rs
+++ b/src/contract/event.rs
@@ -264,12 +264,6 @@ impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
     pub fn stream(self) -> Result<EventStream<T, E>, EventError> {
         EventStream::from_builder(self)
     }
-
-    /// Creates an event stream from the current event builder that first emits
-    /// past events and then continues streaming new events.
-    pub fn stream_with_past_events(self) -> Result<(), EventError> {
-        todo!()
-    }
 }
 
 /// Converts a tokenizable topic into a raw topic for filtering.

--- a/src/contract/event.rs
+++ b/src/contract/event.rs
@@ -463,7 +463,9 @@ pub struct AllEventsBuilder<T: Transport, E: ParseLog> {
     /// includes the transaction hash, then this property will be automatically
     /// set.
     pub deployment_transaction: Option<H256>,
-    /// The block page size to use when doing a paginated query on past events.
+    /// The page size in blocks to use when doing a paginated query on past
+    /// events. This provides no guarantee in how many events will be returned
+    /// per page, but used to limit the block range for the query.
     pub block_page_size: Option<u64>,
     _events: PhantomData<E>,
 }
@@ -580,7 +582,9 @@ impl<T: Transport, E: ParseLog> AllEventsBuilder<T, E> {
             None | Some(BlockNumber::Earliest) => 0,
             Some(BlockNumber::Number(value)) => value.as_u64(),
             Some(BlockNumber::Latest) | Some(BlockNumber::Pending) => {
-                panic!("invalid from block value 'latest' or 'pending'")
+                // NOTE: Query doesn't really make sense, let the node deal with
+                //   it.
+                return self.query().await;
             }
         };
         if let Some(deployment_tx) = self.deployment_transaction {
@@ -592,15 +596,26 @@ impl<T: Transport, E: ParseLog> AllEventsBuilder<T, E> {
 
         let end_block = match self.to_block {
             None | Some(BlockNumber::Latest) | Some(BlockNumber::Pending) => {
+                // NOTE: For latest and pending blocks, we need to set a target
+                //   for the pagination, the last query will use "latest" or
+                //   "paginated" ensuring that all expected events are produced.
                 self.web3.eth().block_number().compat().await?.as_u64()
             }
             Some(BlockNumber::Number(value)) => value.as_u64(),
-            Some(BlockNumber::Earliest) => panic!("invalid to block value 'earliest'"),
+            Some(BlockNumber::Earliest) => {
+                // NOTE: Query doesn't really make sense, let the node deal with
+                //   it.
+                return self.query().await;
+            }
         };
+
+        if start_block > end_block {
+            return Ok(Vec::new());
+        }
+
         let page_size = self.block_page_size.unwrap_or(DEFAULT_BLOCK_PAGE_SIZE);
         let (web3, filter) = self.prepare();
 
-        let mut current_block = start_block;
         let mut events = Vec::new();
         let mut append_events = |logs: Vec<Log>| -> Result<(), ExecutionError> {
             events.reserve(logs.len());
@@ -611,8 +626,10 @@ impl<T: Transport, E: ParseLog> AllEventsBuilder<T, E> {
             Ok(())
         };
 
-        // NOTE: Query only until the last page, since it is handled a little
-        //   differently to deal with "latest" and "pending" to blocks.
+        // NOTE: Query only until the page right before the last one, since it
+        //   is handled a little differently to deal with "latest" and "pending"
+        //   to blocks.
+        let mut current_block = start_block;
         while current_block + page_size <= end_block {
             let filter = filter
                 .clone()
@@ -625,18 +642,15 @@ impl<T: Transport, E: ParseLog> AllEventsBuilder<T, E> {
             current_block += page_size;
         }
 
-        // NOTE: In case this was called with a from block of "latest" or
-        //   "pending" we want to make sure that the last call includes blocks
-        //   that have been added since the start of the call. To do this, we
-        //   just omit the `to_block` from the `filter` since it was already
-        //   specified in the `prepare` method. In the case a block number was
-        //   specified, this call is still correct as the filter's `to_block`
-        //   will be set to that block number.
-        if start_block > end_block {
-            let filter = filter.from_block(current_block.into()).build();
-            let event_page = web3.eth().logs(filter).compat().await?;
-            append_events(event_page)?;
-        }
+        // NOTE: The last page is handled a bit differently by using the
+        //   `to_block` that was originally specified to the builder and is set
+        //   in the `filter` (from the call to `prepare`). This is done in case
+        //   the to block was "latest" or "pending", where we want to make sure
+        //   that the last call includes blocks that have been added since the
+        //   start of the paginated query.
+        let filter = filter.from_block(current_block.into()).build();
+        let event_page = web3.eth().logs(filter).compat().await?;
+        append_events(event_page)?;
 
         Ok(events)
     }

--- a/src/contract/event.rs
+++ b/src/contract/event.rs
@@ -272,50 +272,6 @@ impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
     }
 }
 
-/*
-
-enum CompleteEventStream<T: Transport, E: Tokenizable> {
-    Init {
-        web3: Web3<T>,
-        builder: EventBuilder<T, E>,
-        tx_hash: H256,
-    },
-    Streaming {
-        web3: Web3<T>,
-        builder: EventBuilder<T, E>,
-        query: QueryFuture<T, E>,
-        start_block: u64,
-        current_block: u64,
-        stream: EventStream<T, E>,
-        streamed_events: Event<E>,
-    },
-}
-
-async fn complete_event_stream_step<T: Transport, E: Tokenizable>(
-    mut stream: CompleteEventStream<T, E>,
-) -> Result<Option<(Event<E>, CompleteEventStream<T, E>)>, ExecutionError> {
-    loop {
-        stream = match stream {
-            CompleteEventStream::Init { web3, tx_hash, builder } => {
-                let start_block = block_number_from_transaction_hash(web3, tx_hash).await?;
-                let current_block = web3.eth().block_number().compat().await?;
-
-                let query = builder.clone()
-                    .from_block(start_block)
-                    .to_block(start_block + BLOCK_PAGE_SIZE)
-                    query();
-                let stream = builder.clone().stream();
-
-                CompleteEventStream::Streaming {
-                    web3,
-                    query
-                }
-            }
-        }
-    }
-}
-*/
-
 /// Converts a tokenizable topic into a raw topic for filtering.
 fn tokenize_topic<P>(topic: Topic<P>) -> Topic<Token>
 where

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -94,6 +94,15 @@ pub enum ExecutionError {
     /// This is intended to be implemented in future version of `ethcontract`.
     #[error("unsupported ABI token")]
     UnsupportedToken,
+
+    /// Failed to find a transaction by hash.
+    #[error("missing transaction {0:?}")]
+    MissingTransaction(H256),
+
+    /// Failed to get a block for a pending transaction that has not yet been
+    /// mined.
+    #[error("pending transaction {0:?}, not yet part of a block")]
+    PendingTransaction(H256),
 }
 
 impl From<Web3Error> for ExecutionError {


### PR DESCRIPTION
This PR introduces a new async method that queries past events in block pages.

### Test Plan

Introduced new example that queries all past OWL tokens. Currently that is around 50.000 events :rocket: 
```
Using OWL token at 0x1a5f9352af8af974bfc03399e3767df6370d82e4
Retrieving all past events (this could take a while)...
Total number of events emitted by OWL token 49575
cargo run --example past_events  62.11s user 1.32s system 25% cpu 4:07.99 total
```