### PR TITLE
[Easy] Silence new clippy lint introduced in Rust 1.43

### DIFF
--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -22,17 +22,29 @@ fn expand_deployed(cx: &Context) -> TokenStream {
         return quote! {};
     }
 
-    let deployments = cx.deployments.iter().map(|(network_id, address)| {
-        let network_id = Literal::string(&network_id.to_string());
-        let address = expand_address(*address);
+    let artifact_network = quote! { artifact.networks.get(network_id)?  };
+    let network = if cx.deployments.is_empty() {
+        artifact_network
+    } else {
+        let deployments = cx.deployments.iter().map(|(network_id, address)| {
+            let network_id = Literal::string(&network_id.to_string());
+            let address = expand_address(*address);
+
+            quote! {
+                #network_id => self::ethcontract::common::truffle::Network {
+                    address: #address,
+                    transaction_hash: None,
+                },
+            }
+        });
 
         quote! {
-            #network_id => self::ethcontract::common::truffle::Network {
-                address: #address,
-                transaction_hash: None,
-            },
+            match network_id {
+                #( #deployments )*
+                _ => #artifact_network.clone(),
+            };
         }
-    });
+    };
 
     quote! {
         impl Contract {
@@ -73,11 +85,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
                 _: Self::Context,
             ) -> Option<Self> {
                 let artifact = Self::artifact();
-                #[allow(clippy::match_single_binding)]
-                let network = match network_id {
-                    #( #deployments )*
-                    _ => artifact.networks.get(network_id)?.clone(),
-                };
+                let network = #network;
 
                 Some(Self::with_transaction(
                     &web3,

--- a/generate/src/contract/deployment.rs
+++ b/generate/src/contract/deployment.rs
@@ -73,6 +73,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
                 _: Self::Context,
             ) -> Option<Self> {
                 let artifact = Self::artifact();
+                #[allow(clippy::match_single_binding)]
                 let network = match network_id {
                     #( #deployments )*
                     _ => artifact.networks.get(network_id)?.clone(),


### PR DESCRIPTION
The lint complains that the `match` statement has a single branch, this happens in the generated code when there are no manual deployments.

This PR addresses the issue by generating slightly different code if there are no manual deployments. Just allowing the clippy lint was attempted, but unfortunately the new lint doesn't exist in Rust 1.42 so that would cause other issues as well.

### Test Plan

No clippy lints in `dex-services`.