### PR TITLE
Bump to v0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -31,8 +31,8 @@ members = [
 
 [dependencies]
 ethabi_9_0 = { package = "ethabi", version = "9.0" }
-ethcontract-common = { version = "0.7.0", path = "./common" }
-ethcontract-derive = { version = "0.7.0", path = "./derive", optional = true}
+ethcontract-common = { version = "0.7.1", path = "./common" }
+ethcontract-derive = { version = "0.7.1", path = "./derive", optional = true}
 futures = { version = "0.3", features = ["compat"] }
 futures-timer = "3.0"
 hex = "0.4"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,8 @@ Proc macro for generating type-safe bindings to Ethereum smart contracts.
 proc-macro = true
 
 [dependencies]
-ethcontract-common = { version = "0.7.0", path = "../common" }
-ethcontract-generate = { version = "0.7.0", path = "../generate" }
+ethcontract-common = { version = "0.7.1", path = "../common" }
+ethcontract-generate = { version = "0.7.1", path = "../generate" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.12"

--- a/examples/generate/Cargo.toml
+++ b/examples/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples-generate"
-version = "0.7.0"
+version = "0.7.1"
 publish = false
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"

--- a/examples/truffle/package.json
+++ b/examples/truffle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethcontract-contracts",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": "true",
   "description": "Test contracts for ethcontract-rs runtime and proc macro.",
   "scripts": {

--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ Code generation for type-safe bindings to Ethereum smart contracts.
 [dependencies]
 anyhow = "1.0"
 curl = "0.4"
-ethcontract-common = { version = "0.7.0", path = "../common" }
+ethcontract-common = { version = "0.7.1", path = "../common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"


### PR DESCRIPTION
This minor version bump is to include #288 so silence some lints in the generated code.