### PR TITLE
Division and Remainder for i256

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -695,7 +695,6 @@ impl I256 {
         if self == Self::MIN && rhs == Self::from(-1) {
             (Self::zero(), true)
         } else {
-            // Already handled overflow.
             let div_res = self / rhs;
             (self - div_res * rhs, false)
         }

--- a/src/int.rs
+++ b/src/int.rs
@@ -678,7 +678,7 @@ impl I256 {
     /// Division which saturates at the maximum value..
     pub fn saturating_div(self, rhs: Self) -> Self {
         // There is only one overflow (I256::MIN / -1 = I256::MAX)
-        self.checked_div(rhs).unwrap_or_else(I256::MAX)
+        self.checked_div(rhs).unwrap_or(I256::MAX)
     }
 
     /// Wrapping division.

--- a/src/int.rs
+++ b/src/int.rs
@@ -650,6 +650,47 @@ impl I256 {
         result
     }
 
+    /// Calculates `self` * `rhs`
+    ///
+    /// Returns a tuple of the division along with a boolean indicating
+    /// whether an arithmetic overflow would occur. If an overflow would have
+    /// occurred then the wrapped value is returned.
+    pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
+        // Panic early when getting sign because of division by zero.
+        let sign = Sign::from_signum64(self.signum64() / rhs.signum64());
+        // Note, signed division can't overflow!
+        let unsigned  = self.abs_unsigned() / rhs.abs_unsigned();
+        let (result, overflow_conv) = I256::overflowing_from_sign_and_abs(sign, unsigned);
+
+        (result, overflow_conv && !result.is_zero())
+    }
+
+    /// Checked division. Returns None if overflow occurred.
+    pub fn checked_div(self, other: Self) -> Option<Self> {
+        let (result, overflow) = self.overflowing_div(other);
+        if overflow {
+            None
+        } else {
+            Some(result)
+        }
+    }
+
+    /// Division which saturates at the maximum value..
+    pub fn saturating_div(self, rhs: Self) -> Self {
+        self.checked_div(rhs).unwrap_or_else(|| {
+            match Sign::from_signum64(self.signum64() * rhs.signum64()) {
+                Sign::Positive => I256::MAX,
+                Sign::Negative => I256::MIN,
+            }
+        })
+    }
+
+    /// Wrapping division.
+    pub fn wrapping_div(self, rhs: Self) -> Self {
+        let (result, _) = self.overflowing_div(rhs);
+        result
+    }
+
     /// Returns the sign of `self` to the exponent `exp`.
     ///
     /// Note that this method does not actually try to compute the `self` to the
@@ -997,6 +1038,20 @@ impl ops::Mul for I256 {
 impl ops::MulAssign for I256 {
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
+    }
+}
+
+impl ops::Div for I256 {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        handle_overflow(self.overflowing_div(rhs))
+    }
+}
+
+impl ops::DivAssign for I256 {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
     }
 }
 
@@ -1366,6 +1421,30 @@ mod tests {
         assert_eq!(I256::one() * I256::zero(), I256::zero());
         assert_eq!(I256::MAX * I256::zero(), I256::zero());
         assert_eq!(I256::MIN * I256::zero(), I256::zero());
+    }
+
+    #[test]
+    fn division() {
+        // The only case for overflow.
+        assert_eq!(I256::MIN.overflowing_div(I256::from(-1)), (I256::MIN, true));
+
+        assert_eq!(I256::MIN / I256::MAX, I256::from(-1));
+        assert_eq!(I256::MAX / I256::MIN, I256::zero());
+
+        assert_eq!(I256::MIN / I256::one(), I256::MIN);
+        assert_eq!(I256::from(-42) / I256::from(-21), I256::from(2));
+        assert_eq!(I256::from(-42) / I256::from(2), I256::from(-21));
+        assert_eq!(I256::from(42) / I256::from(-21), I256::from(-2));
+        assert_eq!(I256::from(42) / I256::from(21), I256::from(2));
+
+        // The only saturating corner case.
+        assert_eq!(I256::MIN.saturating_div(I256::from(-1)), I256::MAX);
+    }
+
+    #[test]
+    #[should_panic]
+    fn division_by_zero() {
+        let _ = I256::one() / I256::zero();
     }
 
     #[test]

--- a/src/int.rs
+++ b/src/int.rs
@@ -656,7 +656,7 @@ impl I256 {
     /// whether an arithmetic overflow would occur. If an overflow would have
     /// occurred then the wrapped value is returned.
     pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
-        // Panic early when getting sign because of division by zero.
+        // Panic early when with division by zero while evaluating sign.
         let sign = Sign::from_signum64(self.signum64() / rhs.signum64());
         // Note, signed division can't overflow!
         let unsigned = self.abs_unsigned() / rhs.abs_unsigned();
@@ -677,12 +677,8 @@ impl I256 {
 
     /// Division which saturates at the maximum value..
     pub fn saturating_div(self, rhs: Self) -> Self {
-        self.checked_div(rhs).unwrap_or_else(|| {
-            match Sign::from_signum64(self.signum64() * rhs.signum64()) {
-                Sign::Positive => I256::MAX,
-                Sign::Negative => I256::MIN,
-            }
-        })
+        // There is only one overflow (I256::MIN / -1 = I256::MAX)
+        self.checked_div(rhs).unwrap_or_else(I256::MAX)
     }
 
     /// Wrapping division.

--- a/src/int.rs
+++ b/src/int.rs
@@ -675,7 +675,7 @@ impl I256 {
         }
     }
 
-    /// Division which saturates at the maximum value..
+    /// Division which saturates at the maximum value.
     pub fn saturating_div(self, rhs: Self) -> Self {
         // There is only one overflow (I256::MIN / -1 = I256::MAX)
         self.checked_div(rhs).unwrap_or_else(I256::MAX)


### PR DESCRIPTION
The following new methods were implemented for i256

- [x] overflowing_div(self, rhs: Self) -> (Self, bool)
- [x] checked_div(self, other: Self) -> Option<Self>
- [x] saturating_div(self, rhs: Self) -> Self
- [x] wrapping_div(self, rhs: Self) -> Self
- [x] overflowing_rem(self, rhs: Self) -> (Self, bool)
- [x] checked_rem(self, other: Self) -> Option<Self>
- [x] saturating_rem(self, rhs: Self) -> Self

Note that wrapped remainder doesn't make sense. Also, the i32 docs don't seem to implement saturating for either one of these, but I did here.

https://doc.rust-lang.org/std/primitive.i32.html#method.checked_rem

Partially fulfils #253 