### PR TITLE
[Merged by Bors] - [Events] Separate event types for past event and streamed events

### DIFF
--- a/examples/abi.rs
+++ b/examples/abi.rs
@@ -76,8 +76,8 @@ async fn events(instance: &AbiTypes) {
                 .await
                 .expect(concat!(stringify!($events), " failed"));
             let event_data = events
-                .iter()
-                .map(|event| event.inner_data())
+                .into_iter()
+                .map(|event| event.data)
                 .collect::<Vec<_>>();
             println!("{}()\n  ⏎ {:?}", stringify!($events), event_data);
         }};
@@ -104,7 +104,7 @@ async fn events(instance: &AbiTypes) {
         .await
         .expect("failed to retrieve all events");
     for event in all_events {
-        if let abi_types::Event::Values(data) = event.inner_data() {
+        if let abi_types::Event::Values(data) = event.data {
             println!("anonymous event\n  ⏎ {:?}", data);
         }
     }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -21,8 +21,8 @@ use web3::Transport;
 
 pub use self::deploy::{Deploy, DeployBuilder};
 pub use self::event::{
-    AllEventsBuilder, Event, EventBuilder, EventData, EventMetadata, EventStream, ParseLog,
-    QueryFuture, RawLog, Topic, DEFAULT_POLL_INTERVAL,
+    AllEventsBuilder, Event, EventBuilder, EventMetadata, EventStatus, EventStream, ParseLog,
+    QueryFuture, RawLog, StreamEvent, Topic, DEFAULT_POLL_INTERVAL,
 };
 pub use self::method::{
     CallFuture, Detokenizable, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture,

--- a/src/contract/event/data.rs
+++ b/src/contract/event/data.rs
@@ -18,7 +18,8 @@ pub struct Event<T> {
 
 /// A contract event from an event stream.
 ///
-/// This is similar to `Event`s except they may
+/// This is similar to `Event`s except the event may either be added (in case a
+/// new block is mined) or removed (in case of re-orgs when blocks are removed).
 pub type StreamEvent<T> = Event<EventStatus<T>>;
 
 /// A type representing a contract event that was either added or removed. Note

--- a/src/contract/event/data.rs
+++ b/src/contract/event/data.rs
@@ -9,18 +9,23 @@ use web3::types::{Log, H256};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Event<T> {
     /// The decoded log data.
-    pub data: EventData<T>,
+    pub data: T,
     /// The additional metadata for the event. Note that this is not always
     /// available if these logs are pending. This can happen if the `to_block`
     /// option was set to `BlockNumber::Pending`.
     pub meta: Option<EventMetadata>,
 }
 
+/// A contract event from an event stream.
+///
+/// This is similar to `Event`s except they may
+pub type StreamEvent<T> = Event<EventStatus<T>>;
+
 /// A type representing a contract event that was either added or removed. Note
 /// that this type intentionally an enum so that the handling of removed events
 /// is made more explicit.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum EventData<T> {
+pub enum EventStatus<T> {
     /// A new event was received.
     Added(T),
     /// A previously mined event was removed as a result of a re-org.
@@ -29,21 +34,39 @@ pub enum EventData<T> {
 
 impl<T> Event<T> {
     /// Creates an event from a log given a mapping function.
-    pub(crate) fn from_log<E, F>(log: Log, f: F) -> Result<Self, E>
+    pub(crate) fn from_past_log<E, F>(log: Log, f: F) -> Result<Self, ExecutionError>
     where
         F: FnOnce(RawLog) -> Result<T, E>,
+        ExecutionError: From<E>,
     {
-        let meta = EventMetadata::from_log(&log);
-        let data = {
-            let removed = log.removed == Some(true);
-            let raw = RawLog::from(log);
-            let inner_data = f(raw)?;
+        if log.removed == Some(true) {
+            return Err(ExecutionError::RemovedLog(Box::new(log)));
+        }
 
-            if removed {
-                EventData::Removed(inner_data)
-            } else {
-                EventData::Added(inner_data)
-            }
+        let meta = EventMetadata::from_log(&log);
+        let raw = RawLog::from(log);
+        let data = f(raw)?;
+
+        Ok(Event { data, meta })
+    }
+}
+
+impl<T> Event<EventStatus<T>> {
+    /// Creates an event from a log given a mapping function.
+    pub(crate) fn from_streamed_log<E, F>(log: Log, f: F) -> Result<Self, ExecutionError>
+    where
+        F: FnOnce(RawLog) -> Result<T, E>,
+        ExecutionError: From<E>,
+    {
+        let removed = log.removed == Some(true);
+        let meta = EventMetadata::from_log(&log);
+        let raw = RawLog::from(log);
+        let inner_data = f(raw)?;
+
+        let data = if removed {
+            EventStatus::Removed(inner_data)
+        } else {
+            EventStatus::Added(inner_data)
         };
 
         Ok(Event { data, meta })
@@ -53,26 +76,26 @@ impl<T> Event<T> {
     /// event was added or removed.
     pub fn inner_data(&self) -> &T {
         match &self.data {
-            EventData::Added(value) => value,
-            EventData::Removed(value) => value,
+            EventStatus::Added(value) => value,
+            EventStatus::Removed(value) => value,
         }
     }
 
     /// Gets a bool representing if the event was added.
     pub fn is_added(&self) -> bool {
-        matches!(&self.data, EventData::Added(_))
+        matches!(&self.data, EventStatus::Added(_))
     }
 
     /// Gets a bool representing if the event was removed.
     pub fn is_removed(&self) -> bool {
-        matches!(&self.data, EventData::Removed(_))
+        matches!(&self.data, EventStatus::Removed(_))
     }
 
     /// Get the underlying event data if the event was added, `None` otherwise.
     pub fn added(self) -> Option<T> {
         match self.data {
-            EventData::Added(value) => Some(value),
-            EventData::Removed(_) => None,
+            EventStatus::Added(value) => Some(value),
+            EventStatus::Removed(_) => None,
         }
     }
 
@@ -80,20 +103,20 @@ impl<T> Event<T> {
     /// otherwise.
     pub fn removed(self) -> Option<T> {
         match self.data {
-            EventData::Removed(value) => Some(value),
-            EventData::Added(_) => None,
+            EventStatus::Removed(value) => Some(value),
+            EventStatus::Added(_) => None,
         }
     }
 
     /// Maps the inner data of an event into some other data.
-    pub fn map<U, F>(self, f: F) -> Event<U>
+    pub fn map<U, F>(self, f: F) -> StreamEvent<U>
     where
         F: FnOnce(T) -> U,
     {
         Event {
             data: match self.data {
-                EventData::Added(inner) => EventData::Added(f(inner)),
-                EventData::Removed(inner) => EventData::Removed(f(inner)),
+                EventStatus::Added(inner) => EventStatus::Added(f(inner)),
+                EventStatus::Removed(inner) => EventStatus::Removed(f(inner)),
             },
             meta: self.meta,
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use uint::FromDecStrErr;
 use web3::contract::Error as Web3ContractError;
 use web3::error::Error as Web3Error;
-use web3::types::{TransactionReceipt, H256};
+use web3::types::{Log, TransactionReceipt, H256};
 
 /// Error that can occur while locating a deployed contract.
 #[derive(Debug, Error)]
@@ -95,6 +95,10 @@ pub enum ExecutionError {
     /// mined.
     #[error("pending transaction {0:?}, not yet part of a block")]
     PendingTransaction(H256),
+
+    /// A removed log was received when querying past logs.
+    #[error("unexepected removed log when querying past logs")]
+    RemovedLog(Box<Log>),
 }
 
 impl From<Web3Error> for ExecutionError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,9 @@ pub mod prelude {
     //! A prelude module for importing commonly used types when interacting with
     //! generated contracts.
 
-    pub use crate::contract::{Event, EventData, EventMetadata, RawLog, Topic, Void};
+    pub use crate::contract::{
+        Event, EventMetadata, EventStatus, RawLog, StreamEvent, Topic, Void,
+    };
     pub use crate::int::I256;
     pub use crate::secret::{Password, PrivateKey};
     pub use crate::transaction::{Account, GasPrice};


### PR DESCRIPTION
This PR introduces separate types for past events and streamed events. This is because past events can't ever be "removed" (only events from `eth_getFilterChanges` can be) so library consumers are forced to handle a case that can't actually happen.

### Test Plan

CI passes with unit tests and examples