### PR TITLE
[Merged by Bors] - [Async] Implement sending contract method transaction with async/await

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -25,7 +25,7 @@ pub use self::event::{
     StreamEvent, Topic,
 };
 pub use self::method::{
-    CallFuture, Detokenizable, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture,
+    Detokenizable, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture,
     ViewMethodBuilder, Void,
 };
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -24,10 +24,7 @@ pub use self::event::{
     AllEventsBuilder, Event, EventBuilder, EventMetadata, EventStatus, ParseLog, RawLog,
     StreamEvent, Topic,
 };
-pub use self::method::{
-    Detokenizable, MethodBuilder, MethodDefaults, MethodFuture, MethodSendFuture,
-    ViewMethodBuilder, Void,
-};
+pub use self::method::{Detokenizable, MethodBuilder, MethodDefaults, ViewMethodBuilder, Void};
 
 /// Represents a contract instance at an address. Provides methods for
 /// contract interaction.


### PR DESCRIPTION
This PR implements the `MethodBuidler::send` method with async/await.

### Test Plan

CI