### PR TITLE
[Merged by Bors] - [CI] Delete branch after merge

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,4 +2,5 @@ status = [
   "continuous-integration/travis-ci/push"
 ]
 required-approvals = 1
+delete-merged-branches = true
 use-squash-merge = true


### PR DESCRIPTION
This PR enables the Bors setting to delete a branch after merge, as indicated by the [TOML configuration reference](https://bors.tech/documentation/#configuration-borstoml).

### Test Plan

This branch should be deleted after it is merged by Bors.