### PR TITLE
[CI] Remove Bors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 branches:
   only:
-    # NOTE: The `staging` and `trying` branches are used by bors for performing
-    #   continuous integration checks.
-    - staging
-    - trying
     - master
 
 os: linux

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-status = [
-  "continuous-integration/travis-ci/push"
-]
-required-approvals = 1
-delete-merged-branches = true
-use-squash-merge = true


### PR DESCRIPTION
This PR removes Bors configuration.

My short experience with Bors was very positive, but I don't think it fits the current workflow needs for this project.
- [+/-] Explicitely running CI is cool - it definitely keeps Travis from getting "clogged" by too many PRs and builds. Unfortunately, it also subverts some expectations and workflows we are used to - sometimes I forget I have to ask Bors to trigger a build.
- [+] The ability to run CI for multiple PRs concurrently is also really neat - it makes merging multiple independent PRs MUCH quicker
- [+] It guarantees that the code on master is identical to the code run in CI (requiring PRs to be up to date with master does the same thing, but is much slower and requires manual intervention and clicking on "Update to master")
- [-] It does not play nicely with "squash and merge" and causes the PR to be labeled as "Closed" instead of "Merged".
- [-] Unfortunately, it also slows down dependendabots abitility to test updates (although, arguably this can be fixed in the .travis.yml file).