### PR TITLE
[Easy] Fix past events example

### DIFF
--- a/examples/past_events.rs
+++ b/examples/past_events.rs
@@ -29,6 +29,7 @@ async fn run() {
     println!("Retrieving all past events (this could take a while)...");
     let event_history = owl_token
         .all_events()
+        .from_block(BlockNumber::Earliest)
         .query_paginated()
         .await
         .expect("Couldn't retrieve event history");


### PR DESCRIPTION
The events builder was refactored to match the JS web3 behaviour to default to using `"latest"` block when no `from_block` is specified. For querying past events, this means that the `from_block` typically needs to be specified.

Fixes #343.

### Test Plan

```
$ cargo run --example past_events
    Finished dev [unoptimized + debuginfo] target(s) in 5.25s
     Running `target/debug/examples/past_events`
Using OWL token at 0x1a5f9352af8af974bfc03399e3767df6370d82e4
Retrieving all past events (this could take a while)...
Total number of events emitted by OWL token 58082
```