### PR TITLE
Make web3 features optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,13 @@ to Ethereum smart contracts.
 name = "ethcontract"
 
 [features]
-default = ["derive"]
+default = ["derive", "http", "http-tls", "ws", "ws-tls"]
 derive = ["ethcontract-derive"]
 samples = []
+http = ["web3/http"]
+http-tls = ["web3/http-tls"]
+ws = ["web3/ws"]
+ws-tls = ["web3/ws-tls"]
 
 [workspace]
 members = [
@@ -42,7 +46,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 uint = "0.8"
-web3 = "0.13"
+web3 = { version = "0.13", default-features = false }
 zeroize = "1.1"
 
 [dev-dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,4 +19,4 @@ serde_derive = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
-web3 = "0.13"
+web3 = { version = "0.13", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ pub mod prelude {
     pub use crate::secret::{Password, PrivateKey};
     pub use crate::transaction::{Account, GasPrice};
     pub use web3::api::Web3;
+    #[cfg(feature = "http")]
     pub use web3::transports::Http;
     pub use web3::types::{Address, BlockId, BlockNumber, TransactionCondition, H160, H256, U256};
 }


### PR DESCRIPTION
These web3 features introduce more dependencies which should be optional
for users of ethcontract.