### PR TITLE
Fix clippy warnings and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ branches:
     - main
 
 os: linux
-dist: bionic
+dist: focal
 language: rust
 
 jobs:
   fast_finish: true
   include:
     - stage: "Build and Test"
-      name: "Rust: 1.42.0"
-      rust: 1.42.0
+      name: "Rust: 1.47.0"
+      rust: 1.47.0
     - name: "Rust: stable"
       rust: stable
     - name: "Rust: beta"
@@ -22,10 +22,10 @@ jobs:
     - name: "Rust: stable - Examples"
       rust: stable
       script:
-        # NOTE: We pipe `tail -f /dev/null` into `yarn start`, which internally
-        #   calls `truffle develop`, so that the process' STDIN stays open, as
-        #   `truffle develop` exits as soon as it gets an EOF from STDIN.
-        - tail -f /dev/null | yarn --cwd examples/truffle start > /dev/null &
+        - npm install -g truffle
+        # NOTE: We pipe `tail -f /dev/null`, so that the process' STDIN stays
+        # open, as `truffle develop` exits as soon as it gets an EOF from STDIN.
+        - (cd examples/truffle; tail -f /dev/null | truffle develop > /dev/null) &
         - cargo run --example abi
         - cargo run --example async
         - cargo run --example deployments

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/gnosis/ethcontract-rs.svg?branch=main)](https://travis-ci.org/gnosis/ethcontract-rs)
 [![Crates.io](https://img.shields.io/crates/v/ethcontract.svg)](https://crates.io/crates/ethcontract)
 [![Docs.rs](https://docs.rs/ethcontract/badge.svg)](https://docs.rs/ethcontract)
-[![Rustc Version](https://img.shields.io/badge/rustc-1.42+-lightgray.svg)](https://blog.rust-lang.org/2019/12/19/Rust-1.42.0.html)
+[![Rustc Version](https://img.shields.io/badge/rustc-1.47+-lightgray.svg)](https://blog.rust-lang.org/2019/12/19/Rust-1.47.0.html)
 
 # `ethcontract-rs`
 

--- a/src/errors/parity.rs
+++ b/src/errors/parity.rs
@@ -13,8 +13,7 @@ const INVALID: &str = "Bad instruction";
 /// Returns `None` when a more accurate error cannot be determined.
 pub fn get_encoded_error(err: &JsonrpcError) -> Option<ExecutionError> {
     let message = get_error_message(err)?;
-    if message.starts_with(REVERTED) {
-        let hex = &message[REVERTED.len()..];
+    if let Some(hex) = message.strip_prefix(REVERTED) {
         if hex.is_empty() {
             return Some(ExecutionError::Revert(None));
         } else {

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -34,14 +34,8 @@ impl PrivateKey {
     /// Creates a new private key from a hex string representation. Accepts hex
     /// string with or without leading `"0x"`.
     pub fn from_hex_str<S: AsRef<str>>(s: S) -> Result<Self, InvalidPrivateKey> {
-        let hex_str = {
-            let s = s.as_ref();
-            if s.starts_with("0x") {
-                &s[2..]
-            } else {
-                s
-            }
-        };
+        let s = s.as_ref();
+        let hex_str = s.strip_prefix("0x").unwrap_or(s);
         let secret_key = SecretKey::from_str(hex_str)?;
         Ok(PrivateKey(Zeroizing::new(secret_key.into())))
     }


### PR DESCRIPTION
For the CI part I do not know what actually broke. What we observe is that the examples can't connect to truffle when run through `yarn start`. This is fixed by running `truffle develop` directly but `npm install -g truffle` fails on `ubuntu:bionic` so I upgraded to `ubuntu:focal`.