### PR TITLE
Fix test as overflows panic only on debug

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -1650,7 +1650,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn div_euclid_overflow() {
         I256::MIN.div_euclid(-I256::one());
     }


### PR DESCRIPTION
Fixes #397 

This PR fixes the division overflow test to only expect a panic when building in debug mode (as, just like for the Rust primitive types, overflows are wrapping operations in release builds but panic in debug builds).

### Test Plan

Test passes in both release and debug modes:
```
$ cargo test div_euclid_overflow
    Finished test [unoptimized + debuginfo] target(s) in 0.08s
     Running /var/home/nlordell/Developer/ethcontract-rs/target/debug/deps/ethcontract-bc2a6f1119b35759

running 1 test
test int::tests::div_euclid_overflow ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 89 filtered out

$ cargo test --release div_euclid_overflow
    Finished release [optimized] target(s) in 0.09s
     Running /var/home/nlordell/Developer/ethcontract-rs/target/release/deps/ethcontract-b1c6c1ffce6ac7ba

running 1 test
test int::tests::div_euclid_overflow ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 89 filtered out

```