### PR TITLE
Use truffle from package.json and yarn.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,9 @@ jobs:
     - name: "Rust: stable - Examples"
       rust: stable
       script:
-        - npm install -g truffle
         # NOTE: We pipe `tail -f /dev/null`, so that the process' STDIN stays
         # open, as `truffle develop` exits as soon as it gets an EOF from STDIN.
-        - (cd examples/truffle; tail -f /dev/null | truffle develop > /dev/null) &
+        - (cd examples/truffle; tail -f /dev/null | yarn run -s start > /dev/null) &
         - cargo run --example abi
         - cargo run --example async
         - cargo run --example deployments


### PR DESCRIPTION
Make sure to use the `truffle` installed from `package.json` and `yarn.lock` so that it has a known version.

### Test Plan

Examples job passes: https://travis-ci.com/github/gnosis/ethcontract-rs/jobs/448382220

Note that the current CI failure is related to #410 