### PR TITLE
Allow unprefixed bytecode

### DIFF
--- a/common/src/bytecode.rs
+++ b/common/src/bytecode.rs
@@ -28,16 +28,16 @@ impl Bytecode {
             return Ok(Bytecode::default());
         }
 
-        // check if we start with 0x
-        let mut offset = 0;
-        if s.starts_with("0x") {
-            offset = 2;
-        }
         // and that the length is even
         if s.len() % 2 != 0 {
             return Err(BytecodeError::InvalidLength);
         }
 
+        // account for optional 0x prefix
+        let mut offset = 0;
+        if s.starts_with("0x") {
+            offset = 2;
+        }
         // verify that each code block is valid hex
         for block in CodeIter(&s[offset..]) {
             let block = block?;
@@ -52,7 +52,7 @@ impl Bytecode {
             }
         }
 
-        Ok(Bytecode(s[2..].to_string()))
+        Ok(Bytecode(s[offset..].to_string()))
     }
 
     /// Link a library into the current bytecode.

--- a/common/src/bytecode.rs
+++ b/common/src/bytecode.rs
@@ -37,7 +37,7 @@ impl Bytecode {
         let s = s.strip_prefix("0x").unwrap_or(s);
 
         // verify that each code block is valid hex
-        for block in CodeIter(&s[0..]) {
+        for block in CodeIter(s) {
             let block = block?;
 
             if let Some(pos) = block
@@ -50,7 +50,7 @@ impl Bytecode {
             }
         }
 
-        Ok(Bytecode(s[0..].to_string()))
+        Ok(Bytecode(s.to_string()))
     }
 
     /// Link a library into the current bytecode.

--- a/common/src/bytecode.rs
+++ b/common/src/bytecode.rs
@@ -28,18 +28,16 @@ impl Bytecode {
             return Ok(Bytecode::default());
         }
 
-        // and that the length is even
+        // Verify that the length is even
         if s.len() % 2 != 0 {
             return Err(BytecodeError::InvalidLength);
         }
 
         // account for optional 0x prefix
-        let mut offset = 0;
-        if s.starts_with("0x") {
-            offset = 2;
-        }
+        let s = s.strip_prefix("0x").unwrap_or(s);
+
         // verify that each code block is valid hex
-        for block in CodeIter(&s[offset..]) {
+        for block in CodeIter(&s[0..]) {
             let block = block?;
 
             if let Some(pos) = block
@@ -52,7 +50,7 @@ impl Bytecode {
             }
         }
 
-        Ok(Bytecode(s[offset..].to_string()))
+        Ok(Bytecode(s[0..].to_string()))
     }
 
     /// Link a library into the current bytecode.

--- a/common/src/bytecode.rs
+++ b/common/src/bytecode.rs
@@ -28,9 +28,10 @@ impl Bytecode {
             return Ok(Bytecode::default());
         }
 
-        // check that we start with 0x
-        if !s.starts_with("0x") {
-            return Err(BytecodeError::MissingHexPrefix);
+        // check if we start with 0x
+        let mut offset = 0;
+        if s.starts_with("0x") {
+            offset = 2;
         }
         // and that the length is even
         if s.len() % 2 != 0 {
@@ -38,7 +39,7 @@ impl Bytecode {
         }
 
         // verify that each code block is valid hex
-        for block in CodeIter(&s[2..]) {
+        for block in CodeIter(&s[offset..]) {
             let block = block?;
 
             if let Some(pos) = block
@@ -212,6 +213,11 @@ mod tests {
     #[test]
     fn empty_hex_bytecode_is_empty() {
         assert!(Bytecode::from_hex_str("0x").unwrap().is_empty());
+    }
+
+    #[test]
+    fn unprefixed_hex_bytecode_is_not_empty() {
+        assert!(!Bytecode::from_hex_str("feedface").unwrap().is_empty());
     }
 
     #[test]

--- a/common/src/errors.rs
+++ b/common/src/errors.rs
@@ -19,10 +19,6 @@ pub enum ArtifactError {
 /// An error reading bytecode string representation.
 #[derive(Debug, Error)]
 pub enum BytecodeError {
-    /// Missing hex prefix at start of string.
-    #[error("missing 0x hex prefix at start of bytecode")]
-    MissingHexPrefix,
-
     /// Bytecode string is not an even length.
     #[error("invalid bytecode length")]
     InvalidLength,


### PR DESCRIPTION
Because e.g. [this contract](https://unpkg.com/browse/@uniswap/v2-core@1.0.1/build/UniswapV2Factory.json) exposes its bytecode without the prefix.

### Test Plan

Added unit test.