### PR TITLE
[Easy] Make rustfmt use edition 2018

### DIFF
--- a/generate/src/rustfmt.rs
+++ b/generate/src/rustfmt.rs
@@ -10,6 +10,7 @@ where
     S: AsRef<str>,
 {
     let mut rustfmt = Command::new("rustfmt")
+        .args(&["--edition", "2018"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;


### PR DESCRIPTION
Otherwise we are running into weird errors when vendoring and including a new artefact for the first time:

> error[E0670]: `async fn` is not permitted in the 2015 edition

### Test Plan

Update the version and make sure I can vendor on a clean cargo workspace.