### PR TITLE
Disable auto-bin discovery for example crate

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 publish = false
 edition = "2018"
 license = "MIT OR Apache-2.0"
+autobins = false
 
 [dev-dependencies]
 ethcontract = { path = "../ethcontract", features = ["derive"] }


### PR DESCRIPTION
Fixes #440 

This PR disables auto-binary discovery for the example crate. This is because with Cargo, a binary with the name `examples` is not allowed and Dependabot [sets up a dummy `main.rs` with the manifest](https://github.com/dependabot/dependabot-core/blob/d492ca8a32c7a83e523e0f627fe897b2c0ed72ac/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb#L345), which causes it to try and build as a binary. Another option would be to rename the crate to something like `ethcontract-examples`, but I find that name to be unnecessarily verbose.

### Test Plan

Setup a dummy `main.rs` and build the examples crate (this used to fail):
```
mkdir examples/src && echo "fn main() {}" > examples/src/main.rs
cargo build -p examples
```