### PR TITLE
Update mergify config for github actions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: Merge approved and green PRs with merge-when-green label
     conditions:
       - "#approved-reviews-by>=1"
-      - status-success=Travis CI - Pull Request
+      - status-success~=^rust \(.*, false\)$
       - base=main
       - label=merge when green
     actions:
@@ -13,7 +13,7 @@ pull_request_rules:
   - name: Automatic merge for Dependabot pull requests
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
-      - status-success=Travis CI - Pull Request
+      - status-success~=^rust \(.*, false\)$
       - base=main
     actions:
       merge:


### PR DESCRIPTION
This PR updates the mergify config for the new Github actions CI. it requires status success for jobs that have `continue-on-error == false`, so failures in nightly Rust for example don't prevent merging.

### Test Plan

Mergify configuration changes only apply when merged to master, so once this is merged verify that PRs can be automatically merged with the `merge when green` tag.