### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/ci/bump.sh
+++ b/ci/bump.sh
@@ -67,9 +67,3 @@ for manifest in ethcontract*/Cargo.toml; do
 	msg "  - $manifest"
 	sed -i -E -e 's/^((ethcontract-[a-z]+ = \{ )?version) = "[0-9\.]+"/\1 = "'"$version"'"/g' "$manifest"
 done
-
-msg "Updating npm packages with new version '$version':"
-for package in examples/*/package.json; do
-	msg "  - $package"
-	sed -i -E -e 's/^(  "version":) "[0-9\.]+"/\1 "'"$version"'"/g' "$package"
-done

--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,8 @@ Proc macro for generating type-safe bindings to Ethereum smart contracts.
 proc-macro = true
 
 [dependencies]
-ethcontract-common = { version = "0.9.1", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.9.1", path = "../ethcontract-generate" }
+ethcontract-common = { version = "0.10.0", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.10.0", path = "../ethcontract-generate" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.12"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ Code generation for type-safe bindings to Ethereum smart contracts.
 [dependencies]
 anyhow = "1.0"
 curl = "0.4"
-ethcontract-common = { version = "0.9.1", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.10.0", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -25,8 +25,8 @@ ws-tokio = ["web3/ws-tokio"]
 ws-tls-tokio = ["web3/ws-tls-tokio"]
 
 [dependencies]
-ethcontract-common = { version = "0.9.1", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.9.1", path = "../ethcontract-derive", optional = true}
+ethcontract-common = { version = "0.10.0", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.10.0", path = "../ethcontract-derive", optional = true}
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"

--- a/examples/truffle/package.json
+++ b/examples/truffle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethcontract-contracts",
-  "version": "0.9.1",
+  "version": "0.0.0",
   "private": "true",
   "description": "Test contracts for ethcontract-rs runtime and proc macro.",
   "scripts": {


### PR DESCRIPTION
This PR just a version bump to 0.10.0. Additionally, it follows suit regarding versioning of examples and sets the Truffle example npm package to use `v0.0.0` and remove it from the version bump script.

### Test Plan

CI and release.