### PR TITLE
Implement batching for View methods

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -49,6 +49,7 @@ jobs:
             done
             cargo run --package examples --example abi
             cargo run --package examples --example async
+            cargo run --package examples --example batch
             cargo run --package examples --example deployments
             cargo run --package examples --example events
             cargo run --package examples-generate

--- a/ethcontract/src/batch.rs
+++ b/ethcontract/src/batch.rs
@@ -1,0 +1,88 @@
+//! Module containing components to batch multiple contract calls
+//! into a single request to the Node.
+
+use futures::channel::oneshot::{channel, Sender};
+use web3::{
+    error::Error as Web3Error,
+    helpers::{self},
+    types::{BlockId, BlockNumber, Bytes, CallRequest},
+    BatchTransport as Web3BatchTransport,
+};
+/// Struct allowing to batch multiple calls into a single Node request
+pub struct CallBatch<T: Web3BatchTransport> {
+    inner: T,
+    requests: Vec<(
+        (CallRequest, Option<BlockId>),
+        Sender<Result<Bytes, Web3Error>>,
+    )>,
+}
+
+impl<T: Web3BatchTransport> CallBatch<T> {
+    /// Create a new instance from a BatchTransport
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            requests: Default::default(),
+        }
+    }
+
+    /// Adds a call request to the current batch. The resulting future can only resolve after
+    /// the batch has been resolved via `execute_all`.
+    /// Panics, if the batch is dropped before executing.
+    pub fn push(
+        &mut self,
+        call: CallRequest,
+        block: Option<BlockId>,
+    ) -> impl std::future::Future<Output = Result<Bytes, Web3Error>> {
+        let (tx, rx) = channel();
+        self.requests.push(((call, block), tx));
+        async move { rx.await.expect("Batch has been dropped without executing") }
+    }
+
+    /// Execute and resolve all enqueued CallRequests in a single RPC call
+    pub async fn execute_all(self) -> Result<(), Web3Error> {
+        let results = self
+            .inner
+            .send_batch(self.requests.iter().map(|((request, block), _)| {
+                let req = helpers::serialize(request);
+                let block =
+                    helpers::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
+                let (id, request) = self.inner.prepare("eth_call", vec![req, block]);
+                (id, request)
+            }))
+            .await?;
+        for (result, (_, sender)) in results.into_iter().zip(self.requests.into_iter()) {
+            sender.send(result.and_then(helpers::decode)).unwrap();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::future::join_all;
+    use serde_json::json;
+
+    use super::*;
+    use crate::test::prelude::FutureTestExt;
+    use crate::test::transport::TestTransport;
+
+    #[test]
+    fn batches_calls() {
+        let mut transport = TestTransport::new();
+        transport.add_response(json!([json!("0x01"), json!("0x02")]));
+
+        let mut batch = CallBatch::new(transport);
+
+        let results = vec![
+            batch.push(CallRequest::default(), None),
+            batch.push(CallRequest::default(), None),
+        ];
+
+        batch.execute_all().immediate().unwrap();
+
+        let results = join_all(results).immediate();
+        assert_eq!(results[0].clone().unwrap().0, vec![1u8]);
+        assert_eq!(results[1].clone().unwrap().0, vec![2u8]);
+    }
+}

--- a/ethcontract/src/batch.rs
+++ b/ethcontract/src/batch.rs
@@ -8,14 +8,15 @@ use web3::{
     types::{BlockId, BlockNumber, Bytes, CallRequest},
     BatchTransport as Web3BatchTransport,
 };
+
 /// Struct allowing to batch multiple calls into a single Node request
 pub struct CallBatch<T: Web3BatchTransport> {
     inner: T,
-    requests: Vec<(
-        (CallRequest, Option<BlockId>),
-        Sender<Result<Bytes, Web3Error>>,
-    )>,
+    requests: Vec<(Request, CompletionHandler)>,
 }
+
+type Request = (CallRequest, Option<BlockId>);
+type CompletionHandler = Sender<Result<Bytes, Web3Error>>;
 
 impl<T: Web3BatchTransport> CallBatch<T> {
     /// Create a new instance from a BatchTransport

--- a/ethcontract/src/batch.rs
+++ b/ethcontract/src/batch.rs
@@ -53,7 +53,7 @@ impl<T: Web3BatchTransport> CallBatch<T> {
             }))
             .await?;
         for (result, (_, sender)) in results.into_iter().zip(self.requests.into_iter()) {
-            sender.send(result.and_then(helpers::decode)).unwrap();
+            let _ = sender.send(result.and_then(helpers::decode));
         }
         Ok(())
     }

--- a/ethcontract/src/batch.rs
+++ b/ethcontract/src/batch.rs
@@ -29,6 +29,9 @@ impl<T: Web3BatchTransport> CallBatch<T> {
 
     /// Adds a call request to the current batch. The resulting future can only resolve after
     /// the batch has been resolved via `execute_all`.
+    /// Explicitly returns a Future instead of being declared `async` so that we can split the
+    /// logic into a synchronous and asynchronous section and don't want to capture `&mut self`
+    /// in the future.
     /// Panics, if the batch is dropped before executing.
     pub fn push(
         &mut self,

--- a/ethcontract/src/lib.rs
+++ b/ethcontract/src/lib.rs
@@ -93,6 +93,7 @@
 #[path = "test/macros.rs"]
 mod test_macros;
 
+pub mod batch;
 pub mod contract;
 pub mod errors;
 mod int;

--- a/ethcontract/src/test/transport.rs
+++ b/ethcontract/src/test/transport.rs
@@ -74,7 +74,7 @@ impl BatchTransport for TestTransport {
                 return future::err(Error::Unreachable);
             }
         };
-        future::ok(responses.map(|value| Ok(value.clone())).collect())
+        future::ok(responses.map(Ok).collect())
     }
 }
 

--- a/ethcontract/src/test/transport.rs
+++ b/ethcontract/src/test/transport.rs
@@ -4,9 +4,9 @@
 use jsonrpc_core::{Call, Value};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
-use web3::error::Error;
 use web3::futures::future::{self, Ready};
 use web3::helpers;
+use web3::{error::Error, BatchTransport};
 use web3::{RequestId, Transport};
 
 /// Type alias for request method and value pairs
@@ -44,6 +44,37 @@ impl Transport for TestTransport {
                 future::err(Error::Unreachable)
             }
         }
+    }
+}
+
+impl BatchTransport for TestTransport {
+    type Batch = Ready<Result<Vec<Result<Value, Error>>, Error>>;
+
+    fn send_batch<T>(&self, requests: T) -> Self::Batch
+    where
+        T: IntoIterator<Item = (RequestId, Call)>,
+    {
+        let mut requests: Vec<_> = requests.into_iter().collect();
+
+        // Only send the first request to receive a response for all requests in the batch
+        let (id, call) = match requests.pop() {
+            Some(request) => request,
+            None => return future::ok(Vec::new()),
+        };
+
+        let responses = match self
+            .send(id, call)
+            .into_inner()
+            .ok()
+            .and_then(|value| value.as_array().cloned())
+        {
+            Some(array) => array.into_iter(),
+            None => {
+                println!("Response should return a list of values");
+                return future::err(Error::Unreachable);
+            }
+        };
+        future::ok(responses.map(|value| Ok(value.clone())).collect())
     }
 }
 

--- a/examples/examples/batch.rs
+++ b/examples/examples/batch.rs
@@ -29,19 +29,16 @@ async fn main() {
         .expect("transfer 1->2 failed");
 
     let mut batch = CallBatch::new(web3.transport());
-    let mut calls = Vec::new();
-    calls.push(
+    let calls = vec![
         instance
             .balance_of(accounts[1])
             .view()
             .batch_call(&mut batch),
-    );
-    calls.push(
         instance
             .balance_of(accounts[2])
             .view()
             .batch_call(&mut batch),
-    );
+    ];
     batch.execute_all().await.unwrap();
     for (id, call) in calls.into_iter().enumerate() {
         println!("Call {} returned {}", id, call.await.unwrap());

--- a/examples/examples/batch.rs
+++ b/examples/examples/batch.rs
@@ -1,0 +1,49 @@
+use ethcontract::{batch::CallBatch, prelude::*};
+
+ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
+
+#[tokio::main]
+async fn main() {
+    let http = Http::new("http://localhost:9545").expect("transport failed");
+    let web3 = Web3::new(http);
+
+    let accounts = web3.eth().accounts().await.expect("get accounts failed");
+
+    let instance = RustCoin::builder(&web3)
+        .gas(4_712_388u64.into())
+        .deploy()
+        .await
+        .expect("deployment failed");
+    let name = instance.name().call().await.expect("get name failed");
+    println!("Deployed {} at {:?}", name, instance.address());
+
+    instance
+        .transfer(accounts[1], 1_000_000u64.into())
+        .send()
+        .await
+        .expect("transfer 0->1 failed");
+    instance
+        .transfer(accounts[2], 500_000u64.into())
+        .send()
+        .await
+        .expect("transfer 1->2 failed");
+
+    let mut batch = CallBatch::new(web3.transport());
+    let mut calls = Vec::new();
+    calls.push(
+        instance
+            .balance_of(accounts[1])
+            .view()
+            .batch_call(&mut batch),
+    );
+    calls.push(
+        instance
+            .balance_of(accounts[2])
+            .view()
+            .batch_call(&mut batch),
+    );
+    batch.execute_all().await.unwrap();
+    for (id, call) in calls.into_iter().enumerate() {
+        println!("Call {} returned {}", id, call.await.unwrap());
+    }
+}


### PR DESCRIPTION
Implements #355

This PR adds a new BatchCall component which can enqueue ViewMethods and allows executing all queued calls in one roundtrip to the Node. When adding a view method to the batch a future is returned, that can only resolve once the batch has been executed. 

This can potentially lead to deadlocks (e.g. when the future is awaited before the call batch in the same thread). I considered checking for resolution inside each call future and returning an error if the batch has not yet been resolved, however this would potentially prevent legitimate use cases where we await the individual call futures in one thread and execute the batch in a different one.

Alternatively we could make it so that adding a call returns nothing and waiting on the batch transport returns a list of all responses. However, I wasn't sure how this would work in case we want to enqueue multiple different calls with different signatures. With the proposed solution we keep the type-safety of existing view method calls, which I found convenient.

### Test Plan

Added a unit test and `examples/batch.rs ` for a demonstration on how to use it.