### PR TITLE
Version Bump to 0.10.2

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,8 +15,8 @@ Proc macro for generating type-safe bindings to Ethereum smart contracts.
 proc-macro = true
 
 [dependencies]
-ethcontract-common = { version = "0.10.1", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.10.1", path = "../ethcontract-generate" }
+ethcontract-common = { version = "0.10.2", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.10.2", path = "../ethcontract-generate" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.12"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ Code generation for type-safe bindings to Ethereum smart contracts.
 [dependencies]
 anyhow = "1.0"
 curl = "0.4"
-ethcontract-common = { version = "0.10.1", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.10.2", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -25,8 +25,8 @@ ws-tokio = ["web3/ws-tokio"]
 ws-tls-tokio = ["web3/ws-tls-tokio"]
 
 [dependencies]
-ethcontract-common = { version = "0.10.1", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.10.1", path = "../ethcontract-derive", optional = true}
+ethcontract-common = { version = "0.10.2", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.10.2", path = "../ethcontract-derive", optional = true}
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"


### PR DESCRIPTION
So that we can use CallBatches in dex-services via the crates package. Is it correct that once a release is tagged, github CI will automatically release on crates.io?