### PR TITLE
[CallBatch] Don't roundtrip when batch is empty

### DIFF
--- a/ethcontract/src/batch.rs
+++ b/ethcontract/src/batch.rs
@@ -51,6 +51,10 @@ impl<T: Web3BatchTransport> CallBatch<T> {
 
     /// Execute and resolve all enqueued CallRequests in a single RPC call
     pub async fn execute_all(self) -> Result<(), Web3Error> {
+        if self.requests.is_empty() {
+            return Ok(());
+        }
+
         let batch_result = self
             .inner
             .send_batch(self.requests.iter().map(|((request, block), _)| {
@@ -135,5 +139,12 @@ mod tests {
             Web3Error::Transport(reason) => assert!(reason.starts_with("Batch failed with:")),
             _ => panic!("Wrong Error type"),
         };
+    }
+
+    #[test]
+    fn doesnt_issue_request_on_empty_batch() {
+        let transport = TestTransport::new();
+        let batch = CallBatch::new(transport);
+        assert!(batch.execute_all().immediate().is_ok());
     }
 }

--- a/ethcontract/src/test/transport.rs
+++ b/ethcontract/src/test/transport.rs
@@ -59,7 +59,7 @@ impl BatchTransport for TestTransport {
         // Only send the first request to receive a response for all requests in the batch
         let (id, call) = match requests.pop() {
             Some(request) => request,
-            None => return future::ok(Vec::new()),
+            None => return future::err(Error::Unreachable),
         };
 
         let responses = match self


### PR DESCRIPTION
I noticed some nodes (e.g rpc.xdaichain.com) don't like being called with an empty batch request

> Got invalid response: Error("EOF while parsing a value", line: 1, column: 0)

Also it seems wasteful to do a roundtrip to a node without asking it anything.

### Test Plan
Added unit test