### PR TITLE
Abiv2

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -12,7 +12,7 @@ Common types for ethcontract-rs runtime and proc macro.
 """
 
 [dependencies]
-ethabi = "13.0"
+ethabi-fork-ethcontract = "13.0"
 hex = "0.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/ethcontract-common/src/abiext.rs
+++ b/ethcontract-common/src/abiext.rs
@@ -1,8 +1,8 @@
 //! This module implements extensions to the `ethabi` API.
 
+use crate::abi::{Event, Function, ParamType};
 use crate::errors::ParseParamTypeError;
 use crate::hash::{self, H32};
-use ethabi::{Event, Function, ParamType};
 use serde_json::json;
 
 /// Extension trait for `ethabi::Function`.

--- a/ethcontract-common/src/lib.rs
+++ b/ethcontract-common/src/lib.rs
@@ -12,7 +12,7 @@ pub mod truffle;
 pub use crate::abiext::FunctionExt;
 pub use crate::bytecode::Bytecode;
 pub use crate::truffle::Artifact;
-pub use ethabi::{self as abi, Contract as Abi};
+pub use ethabi_fork_ethcontract::{self as abi, Contract as Abi};
 use serde::Deserialize;
 pub use web3::types::Address;
 pub use web3::types::H256 as TransactionHash;

--- a/ethcontract-common/src/truffle.rs
+++ b/ethcontract-common/src/truffle.rs
@@ -1,8 +1,8 @@
 //! Module for reading and examining data produced by truffle.
 
+use crate::abi::Contract as Abi;
 use crate::errors::ArtifactError;
 use crate::{bytecode::Bytecode, DeploymentInformation};
-use ethabi::Contract as Abi;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::File;
@@ -39,6 +39,7 @@ impl Artifact {
                 functions: HashMap::new(),
                 events: HashMap::new(),
                 fallback: false,
+                receive: false,
             },
             bytecode: Default::default(),
             networks: HashMap::new(),

--- a/ethcontract-derive/src/lib.rs
+++ b/ethcontract-derive/src/lib.rs
@@ -342,6 +342,7 @@ impl Parse for Method {
                 })
                 .collect::<ParseResult<Vec<_>>>()?;
 
+            #[allow(deprecated)]
             Function {
                 name,
                 inputs,
@@ -350,6 +351,7 @@ impl Parse for Method {
                 //   affect its signature.
                 outputs: vec![],
                 constant: false,
+                state_mutability: Default::default(),
             }
         };
         let signature = function.abi_signature();

--- a/ethcontract-generate/src/contract/types.rs
+++ b/ethcontract-generate/src/contract/types.rs
@@ -43,6 +43,9 @@ pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
             let size = Literal::usize_unsuffixed(*n);
             Ok(quote! { [#inner; #size] })
         }
-        ParamType::Tuple(_) => Err(anyhow!("ABIEncoderV2 is currently not supported")),
+        ParamType::Tuple(t) => {
+            let inner = t.iter().map(expand).collect::<Result<Vec<_>>>()?;
+            Ok(quote! { (#(#inner,)*) })
+        }
     }
 }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -25,6 +25,7 @@ ws-tokio = ["web3/ws-tokio"]
 ws-tls-tokio = ["web3/ws-tls-tokio"]
 
 [dependencies]
+arrayvec = "0.5"
 ethcontract-common = { version = "0.11.3", path = "../ethcontract-common" }
 ethcontract-derive = { version = "0.11.3", path = "../ethcontract-derive", optional = true}
 futures = "0.3"

--- a/ethcontract/src/contract/deploy.rs
+++ b/ethcontract/src/contract/deploy.rs
@@ -2,12 +2,12 @@
 //! new contracts.
 
 use crate::errors::{DeployError, ExecutionError};
+use crate::tokens::Tokenize;
 use crate::transaction::{Account, GasPrice, TransactionBuilder, TransactionResult};
 use ethcontract_common::abi::Error as AbiError;
 use ethcontract_common::{Abi, Bytecode};
 use std::marker::PhantomData;
 use web3::api::Web3;
-use web3::contract::tokens::Tokenize;
 use web3::types::{Address, Bytes, H256, U256};
 use web3::Transport;
 
@@ -74,7 +74,10 @@ where
         }
 
         let code = bytecode.to_bytes()?;
-        let params = params.into_tokens();
+        let params = match params.into_token() {
+            ethcontract_common::abi::Token::Tuple(tokens) => tokens,
+            _ => unreachable!("function arguments are always tuples"),
+        };
         let data = match (I::abi(&context).constructor(), params.is_empty()) {
             (None, false) => return Err(AbiError::InvalidData.into()),
             (None, true) => code,

--- a/ethcontract/src/contract/event.rs
+++ b/ethcontract/src/contract/event.rs
@@ -6,6 +6,7 @@ mod data;
 pub use self::data::{Event, EventMetadata, EventStatus, ParseLog, RawLog, StreamEvent};
 use crate::errors::{EventError, ExecutionError};
 use crate::log::LogFilterBuilder;
+use crate::tokens::Tokenize;
 pub use ethcontract_common::abi::Topic;
 use ethcontract_common::{
     abi::{Event as AbiEvent, RawTopicFilter, Token},
@@ -17,14 +18,13 @@ use std::cmp;
 use std::marker::PhantomData;
 use std::time::Duration;
 use web3::api::Web3;
-use web3::contract::tokens::{Detokenize, Tokenizable};
 use web3::types::{Address, BlockNumber, H256};
 use web3::Transport;
 
 /// A builder for creating a filtered stream of contract events that are
 #[derive(Debug)]
 #[must_use = "event builders do nothing unless you stream them"]
-pub struct EventBuilder<T: Transport, E: Detokenize> {
+pub struct EventBuilder<T: Transport, E: Tokenize> {
     /// The underlying web3 instance.
     web3: Web3<T>,
     /// The event ABI data for encoding topic filters and decoding logs.
@@ -36,7 +36,7 @@ pub struct EventBuilder<T: Transport, E: Detokenize> {
     _event: PhantomData<E>,
 }
 
-impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
+impl<T: Transport, E: Tokenize> EventBuilder<T, E> {
     /// Creates a new event builder from a web3 provider and a contract event
     /// and address.
     pub fn new(web3: Web3<T>, event: AbiEvent, address: Address) -> Self {
@@ -74,7 +74,7 @@ impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
     /// actually `topic[1]`.
     pub fn topic0<P>(mut self, topic: Topic<P>) -> Self
     where
-        P: Tokenizable,
+        P: Tokenize,
     {
         self.topics.topic0 = tokenize_topic(topic);
         self
@@ -83,7 +83,7 @@ impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
     /// Adds a filter for the second indexed topic.
     pub fn topic1<P>(mut self, topic: Topic<P>) -> Self
     where
-        P: Tokenizable,
+        P: Tokenize,
     {
         self.topics.topic1 = tokenize_topic(topic);
         self
@@ -92,7 +92,7 @@ impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
     /// Adds a filter for the third indexed topic.
     pub fn topic2<P>(mut self, topic: Topic<P>) -> Self
     where
-        P: Tokenizable,
+        P: Tokenize,
     {
         self.topics.topic2 = tokenize_topic(topic);
         self
@@ -161,7 +161,7 @@ impl<T: Transport, E: Detokenize> EventBuilder<T, E> {
 /// Converts a tokenizable topic into a raw topic for filtering.
 fn tokenize_topic<P>(topic: Topic<P>) -> Topic<Token>
 where
-    P: Tokenizable,
+    P: Tokenize,
 {
     topic.map(|parameter| parameter.into_token())
 }

--- a/ethcontract/src/contract/event/data.rs
+++ b/ethcontract/src/contract/event/data.rs
@@ -1,8 +1,6 @@
 //! Module contains code for parsing and manipulating event data.
-
-use crate::errors::ExecutionError;
-use ethcontract_common::abi::{Event as AbiEvent, RawLog as AbiRawLog};
-use web3::contract::tokens::Detokenize;
+use crate::{errors::ExecutionError, tokens::Tokenize};
+use ethcontract_common::abi::{Event as AbiEvent, RawLog as AbiRawLog, Token};
 use web3::types::{Log, H256};
 
 /// A contract event
@@ -172,7 +170,7 @@ impl RawLog {
     /// Decode raw log data into a tokenizable for a matching event ABI entry.
     pub fn decode<D>(self, event: &AbiEvent) -> Result<D, ExecutionError>
     where
-        D: Detokenize,
+        D: Tokenize,
     {
         let event_log = event.parse_log(AbiRawLog {
             topics: self.topics,
@@ -184,7 +182,7 @@ impl RawLog {
             .into_iter()
             .map(|param| param.value)
             .collect::<Vec<_>>();
-        let data = D::from_tokens(tokens)?;
+        let data = D::from_token(Token::Tuple(tokens))?;
 
         Ok(data)
     }

--- a/ethcontract/src/contract/method.rs
+++ b/ethcontract/src/contract/method.rs
@@ -5,63 +5,14 @@
 use crate::transaction::{Account, GasPrice, TransactionBuilder, TransactionResult};
 use crate::{
     batch::CallBatch,
-    errors::{ExecutionError, MethodError},
+    errors::MethodError,
+    tokens::{Error as TokenError, Tokenize},
 };
 use ethcontract_common::abi::{Function, Token};
 use std::marker::PhantomData;
-use web3::contract::tokens::Detokenize;
-use web3::contract::Error as Web3ContractError;
 use web3::types::{Address, BlockId, Bytes, CallRequest, U256};
 use web3::Transport;
 use web3::{api::Web3, BatchTransport};
-
-/// A void type to represent methods with empty return types.
-///
-/// This is used to work around the fact that `(): !Detokenize`.
-pub struct Void(());
-
-/// Represents a type can detokenize a result.
-pub trait Detokenizable {
-    /// The output that this type detokenizes into.
-    type Output;
-
-    /// Create an instance of `Output` by decoding tokens.
-    fn from_tokens(tokens: Vec<Token>) -> Result<Self::Output, ExecutionError>;
-
-    /// Returns true if this is an empty type.
-    fn is_void() -> bool {
-        false
-    }
-}
-
-impl Detokenizable for Void {
-    type Output = ();
-
-    fn from_tokens(tokens: Vec<Token>) -> Result<Self::Output, ExecutionError> {
-        if !tokens.is_empty() {
-            return Err(Web3ContractError::InvalidOutputType(format!(
-                "Expected no elements, got tokens: {:?}",
-                tokens
-            ))
-            .into());
-        }
-
-        Ok(())
-    }
-
-    fn is_void() -> bool {
-        true
-    }
-}
-
-impl<T: Detokenize> Detokenizable for T {
-    type Output = Self;
-
-    fn from_tokens(tokens: Vec<Token>) -> Result<Self::Output, ExecutionError> {
-        let result = <T as Detokenize>::from_tokens(tokens)?;
-        Ok(result)
-    }
-}
 
 /// Default options to be applied to `MethodBuilder` or `ViewMethodBuilder`.
 #[derive(Clone, Debug, Default)]
@@ -79,7 +30,7 @@ pub struct MethodDefaults {
 /// transactions. This is useful when dealing with view functions.
 #[derive(Debug, Clone)]
 #[must_use = "methods do nothing unless you `.call()` or `.send()` them"]
-pub struct MethodBuilder<T: Transport, R: Detokenizable> {
+pub struct MethodBuilder<T: Transport, R: Tokenize> {
     web3: Web3<T>,
     function: Function,
     /// transaction parameters
@@ -87,22 +38,25 @@ pub struct MethodBuilder<T: Transport, R: Detokenizable> {
     _result: PhantomData<R>,
 }
 
-impl<T: Transport> MethodBuilder<T, Void> {
+impl<T: Transport> MethodBuilder<T, ()> {
     /// Creates a new builder for a transaction invoking the fallback method.
     pub fn fallback(web3: Web3<T>, address: Address, data: Bytes) -> Self {
         // NOTE: We create a fake `Function` entry for the fallback method. This
         //   is OK since it is only ever used for error formatting purposes.
+
+        #[allow(deprecated)]
         let function = Function {
             name: "fallback".into(),
             inputs: vec![],
             outputs: vec![],
             constant: false,
+            state_mutability: Default::default(),
         };
         MethodBuilder::new(web3, function, address, data)
     }
 }
 
-impl<T: Transport, R: Detokenizable> MethodBuilder<T, R> {
+impl<T: Transport, R: Tokenize> MethodBuilder<T, R> {
     /// Creates a new builder for a transaction.
     pub fn new(web3: Web3<T>, function: Function, address: Address, data: Bytes) -> Self {
         MethodBuilder {
@@ -188,7 +142,7 @@ impl<T: Transport, R: Detokenizable> MethodBuilder<T, R> {
     /// as such do not require gas or signing. Note that doing a call with a
     /// block number requires first demoting the `MethodBuilder` into a
     /// `ViewMethodBuilder` and setting the block number for the call.
-    pub async fn call(self) -> Result<R::Output, MethodError> {
+    pub async fn call(self) -> Result<R, MethodError> {
         self.view().call().await
     }
 }
@@ -197,14 +151,14 @@ impl<T: Transport, R: Detokenizable> MethodBuilder<T, R> {
 /// directly send transactions and is for read only method calls.
 #[derive(Debug, Clone)]
 #[must_use = "view methods do nothing unless you `.call()` them"]
-pub struct ViewMethodBuilder<T: Transport, R: Detokenizable> {
+pub struct ViewMethodBuilder<T: Transport, R: Tokenize> {
     /// method parameters
     pub m: MethodBuilder<T, R>,
     /// optional block number
     pub block: Option<BlockId>,
 }
 
-impl<T: Transport, R: Detokenizable> ViewMethodBuilder<T, R> {
+impl<T: Transport, R: Tokenize> ViewMethodBuilder<T, R> {
     /// Create a new `ViewMethodBuilder` by demoting a `MethodBuilder`.
     pub fn from_method(method: MethodBuilder<T, R>) -> Self {
         ViewMethodBuilder {
@@ -254,10 +208,10 @@ impl<T: Transport, R: Detokenizable> ViewMethodBuilder<T, R> {
     }
 }
 
-impl<T: Transport, R: Detokenizable> ViewMethodBuilder<T, R> {
+impl<T: Transport, R: Tokenize> ViewMethodBuilder<T, R> {
     /// Call a contract method. Contract calls do not modify the blockchain and
     /// as such do not require gas or signing.
-    pub async fn call(self) -> Result<R::Output, MethodError> {
+    pub async fn call(self) -> Result<R, MethodError> {
         let eth = &self.m.web3.eth();
         let (function, call, block) = self.decompose();
         let future = eth.call(call, block);
@@ -270,7 +224,7 @@ impl<T: Transport, R: Detokenizable> ViewMethodBuilder<T, R> {
     pub fn batch_call<B: BatchTransport>(
         self,
         batch: &mut CallBatch<B>,
-    ) -> impl std::future::Future<Output = Result<R::Output, MethodError>> {
+    ) -> impl std::future::Future<Output = Result<R, MethodError>> {
         let (function, call, block) = self.decompose();
         let future = batch.push(call, block);
         async move { convert_response::<_, R>(future, function).await }
@@ -294,18 +248,28 @@ impl<T: Transport, R: Detokenizable> ViewMethodBuilder<T, R> {
 
 async fn convert_response<
     F: std::future::Future<Output = Result<Bytes, web3::Error>>,
-    R: Detokenizable,
+    R: Tokenize,
 >(
     future: F,
     function: Function,
-) -> Result<R::Output, MethodError> {
+) -> Result<R, MethodError> {
     let bytes = future
         .await
         .map_err(|err| MethodError::new(&function, err))?;
     let tokens = function
         .decode_output(&bytes.0)
         .map_err(|err| MethodError::new(&function, err))?;
-    let result = R::from_tokens(tokens).map_err(|err| MethodError::new(&function, err))?;
+    let token = match tokens.len() {
+        0 => Token::Tuple(Vec::new()),
+        1 => tokens.into_iter().next().unwrap(),
+        _ => {
+            return Err(MethodError::new(
+                &function,
+                TokenError::WrongNumberOfTokensReturned,
+            ))
+        }
+    };
+    let result = R::from_token(token).map_err(|err| MethodError::new(&function, err))?;
     Ok(result)
 }
 
@@ -316,6 +280,7 @@ mod tests {
     use ethcontract_common::abi::{Param, ParamType};
 
     fn test_abi_function() -> (Function, Bytes) {
+        #[allow(deprecated)]
         let function = Function {
             name: "test".to_owned(),
             inputs: Vec::new(),
@@ -324,6 +289,7 @@ mod tests {
                 kind: ParamType::Uint(256),
             }],
             constant: false,
+            state_mutability: Default::default(),
         };
         let data = function
             .encode_input(&[])

--- a/ethcontract/src/errors.rs
+++ b/ethcontract/src/errors.rs
@@ -13,7 +13,6 @@ use secp256k1::Error as Secp256k1Error;
 use std::num::ParseIntError;
 use thiserror::Error;
 use uint::FromDecStrErr;
-use web3::contract::Error as Web3ContractError;
 use web3::error::Error as Web3Error;
 use web3::types::{Log, TransactionReceipt, H256};
 
@@ -62,7 +61,7 @@ pub enum ExecutionError {
     /// An error occured while ABI decoding the result of a contract method
     /// call.
     #[error("abi decode error: {0}")]
-    AbiDecode(#[from] Web3ContractError),
+    AbiDecode(#[from] AbiError),
 
     /// An error occured while parsing chain ID received from a Web3 call.
     #[error("parse chain ID error: {0}")]
@@ -105,6 +104,10 @@ pub enum ExecutionError {
     /// A stream ended unexpectedly.
     #[error("log stream ended unexpectedly")]
     StreamEndedUnexpectedly,
+
+    /// A tokenization related error.
+    #[error("tokenization error: {0}")]
+    Tokenization(#[from] crate::tokens::Error),
 }
 
 impl From<Web3Error> for ExecutionError {
@@ -122,12 +125,6 @@ impl From<Web3Error> for ExecutionError {
         }
 
         ExecutionError::Web3(err)
-    }
-}
-
-impl From<AbiError> for ExecutionError {
-    fn from(err: AbiError) -> Self {
-        ExecutionError::AbiDecode(err.into())
     }
 }
 

--- a/ethcontract/src/errors/revert.rs
+++ b/ethcontract/src/errors/revert.rs
@@ -40,6 +40,7 @@ mod tests {
     use ethcontract_common::abi::{Function, Param, Token};
 
     pub fn encode_reason(reason: &str) -> Vec<u8> {
+        #[allow(deprecated)]
         let revert = Function {
             name: "Error".into(),
             inputs: vec![Param {
@@ -48,6 +49,7 @@ mod tests {
             }],
             outputs: Vec::new(),
             constant: true,
+            state_mutability: Default::default(),
         };
         revert
             .encode_input(&[Token::String(reason.into())])

--- a/ethcontract/src/int.rs
+++ b/ethcontract/src/int.rs
@@ -1,6 +1,5 @@
 //! This module contains an 256-bit signed integer implementation.
 
-use crate::common::abi::Token;
 use crate::errors::{ParseI256Error, TryFromBigIntError};
 use serde::{Deserialize, Serialize};
 use std::cmp;
@@ -10,7 +9,6 @@ use std::iter;
 use std::ops;
 use std::str;
 use std::{i128, i64, u64};
-use web3::contract::{self, tokens};
 use web3::types::U256;
 
 /// Compute the two's complement of a U256.
@@ -1213,26 +1211,11 @@ impl iter::Product for I256 {
     }
 }
 
-impl tokens::Tokenizable for I256 {
-    fn from_token(token: Token) -> Result<Self, contract::Error> {
-        // NOTE: U256 accepts both `Int` and `Uint` kind tokens. In fact, all
-        //   integer types are expected to accept both.
-        Ok(I256(U256::from_token(token)?))
-    }
-
-    fn into_token(self) -> Token {
-        Token::Int(self.0)
-    }
-}
-
-impl tokens::TokenizableItem for I256 {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use lazy_static::lazy_static;
     use serde_json::json;
-    use web3::contract::tokens::Tokenizable;
 
     lazy_static! {
         static ref MIN_ABS: U256 = U256::from(1) << 255;
@@ -1696,20 +1679,8 @@ mod tests {
     }
 
     #[test]
-    fn tokenization() {
+    fn json() {
         assert_eq!(json!(I256::from(42)), json!("0x2a"));
         assert_eq!(json!(I256::minus_one()), json!(U256::MAX));
-
-        assert_eq!(I256::from(42).into_token(), 42i32.into_token());
-        assert_eq!(I256::minus_one().into_token(), Token::Int(U256::MAX),);
-
-        assert_eq!(
-            I256::from_token(42i32.into_token()).unwrap(),
-            I256::from(42),
-        );
-        assert_eq!(
-            I256::from_token(U256::MAX.into_token()).unwrap(),
-            I256::minus_one(),
-        );
     }
 }

--- a/ethcontract/src/lib.rs
+++ b/ethcontract/src/lib.rs
@@ -99,6 +99,7 @@ pub mod errors;
 mod int;
 pub mod log;
 pub mod secret;
+pub mod tokens;
 pub mod transaction;
 pub mod transport;
 
@@ -117,9 +118,7 @@ pub mod prelude {
     //! A prelude module for importing commonly used types when interacting with
     //! generated contracts.
 
-    pub use crate::contract::{
-        Event, EventMetadata, EventStatus, RawLog, StreamEvent, Topic, Void,
-    };
+    pub use crate::contract::{Event, EventMetadata, EventStatus, RawLog, StreamEvent, Topic};
     pub use crate::int::I256;
     pub use crate::secret::{Password, PrivateKey};
     pub use crate::transaction::{Account, GasPrice};

--- a/ethcontract/src/log.rs
+++ b/ethcontract/src/log.rs
@@ -158,7 +158,12 @@ impl<T: Transport> LogFilterBuilder<T> {
             filter = filter.address(self.address);
         }
         if self.topics != TopicFilter::default() {
-            filter = filter.topic_filter(self.topics)
+            filter = filter.topics(
+                topic_to_option(self.topics.topic0),
+                topic_to_option(self.topics.topic1),
+                topic_to_option(self.topics.topic2),
+                topic_to_option(self.topics.topic3),
+            );
         }
         if let Some(limit) = self.limit {
             filter = filter.limit(limit)
@@ -208,6 +213,15 @@ impl<T: Transport> LogFilterBuilder<T> {
             Ok(stream)
         }
         .try_flatten_stream()
+    }
+}
+
+/// Converts a `Topic` to an equivalent `Option<Vec<T>>`, suitable for `FilterBuilder::topics`
+fn topic_to_option(topic: Topic<H256>) -> Option<Vec<H256>> {
+    match topic {
+        Topic::Any => None,
+        Topic::OneOf(v) => Some(v),
+        Topic::This(t) => Some(vec![t]),
     }
 }
 

--- a/ethcontract/src/tokens.rs
+++ b/ethcontract/src/tokens.rs
@@ -47,11 +47,6 @@ pub enum Error {
     /// Tokenize::from_token token is tuple with wrong length.
     #[error("expected a different number of tokens in tuple")]
     TupleLengthMismatch,
-    /// Methods should only ever return 0 or 1 token because multiple return types are grouped into
-    /// into a tuple which is a single token. If a method nonetheless returns more than 1 token this
-    /// error occurs.
-    #[error("a method returned an unexpected number of tokens")]
-    WrongNumberOfTokensReturned,
 }
 
 /// Rust type and single token conversion.

--- a/ethcontract/src/tokens.rs
+++ b/ethcontract/src/tokens.rs
@@ -1,0 +1,454 @@
+//! Tokenization related functionality allowing rust types to be mapped to solidity types.
+
+// This file is based on https://github.com/tomusdrw/rust-web3/blob/e6d044a28458be9a3ee31108475d787e0440ce8b/src/contract/tokens.rs .
+// Generated contract bindings should operate on native rust types for ease of use. To encode them
+// with ethabi we need to map them to ethabi tokens. Tokenize does this for base types like
+// u32 and compounds of other Tokenize in the form of vectors, arrays and tuples.
+//
+// This is complicated by `Vec<u8>` representing `Token::Bytes` (and `[u8; n]` `Token::FixedBytes`)
+// preventing us from having a generic `impl<T: Tokenize> for Vec<T>` as this would lead to
+// conflicting implementations. As a workaround we use an intermediate trait `TokenizeArray`
+// that is implemented for all types that implement `Tokenize` except `Vec<u8>` and
+// `[u8; n]` and then only implement `Tokenize` for vectors and arrays of
+// `TokenizeArray`.
+//
+// The drawback is that if a solidity function actually used an array of u8 instead of bytes then we
+// would not be able to interact with it. An alternative solution could be to use a Bytes new type
+// but this makes calling those functions slightly more annoying.
+//
+// In some cases like when passing arguments to `MethodBuilder` or decoding events we need to be
+// able to pack multiple types into a single generic parameter. This is accomplished by representing
+// the collection of arguments as a tuple.
+//
+// A completely different approach could be to avoid using the trait system and instead encode all
+// rust types into tokens directly in the ethcontract generated bindings.
+
+use crate::I256;
+use arrayvec::ArrayVec;
+use ethcontract_common::{abi::Token, TransactionHash};
+use std::convert::TryInto;
+use web3::types::{Address, U256};
+
+/// A tokenization related error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Tokenize::from_token token type doesn't match the rust type.
+    #[error("expected a different token type")]
+    TypeMismatch,
+    /// Tokenize::from_token is called with integer that doesn't fit in the rust type.
+    #[error("abi integer is does not fit rust integer")]
+    IntegerMismatch,
+    /// Tokenize::from_token token is fixed bytes with wrong length.
+    #[error("expected a different number of fixed bytes")]
+    FixedBytesLengthsMismatch,
+    /// Tokenize::from_token token is fixed array with wrong length.
+    #[error("expected a different number of tokens in fixed array")]
+    FixedArrayLengthsMismatch,
+    /// Tokenize::from_token token is tuple with wrong length.
+    #[error("expected a different number of tokens in tuple")]
+    TupleLengthMismatch,
+    /// Methods should only ever return 0 or 1 token because multiple return types are grouped into
+    /// into a tuple which is a single token. If a method nonetheless returns more than 1 token this
+    /// error occurs.
+    #[error("a method returned an unexpected number of tokens")]
+    WrongNumberOfTokensReturned,
+}
+
+/// Rust type and single token conversion.
+pub trait Tokenize {
+    /// Convert self into token.
+    fn from_token(token: Token) -> Result<Self, Error>
+    where
+        Self: Sized;
+
+    /// Convert token into Self.
+    fn into_token(self) -> Token;
+}
+
+impl Tokenize for Vec<u8> {
+    fn from_token(token: Token) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        match token {
+            Token::Bytes(bytes) => Ok(bytes),
+            _ => Err(Error::TypeMismatch),
+        }
+    }
+
+    fn into_token(self) -> Token {
+        Token::Bytes(self)
+    }
+}
+
+impl Tokenize for String {
+    fn from_token(token: Token) -> Result<Self, Error> {
+        match token {
+            Token::String(s) => Ok(s),
+            _ => Err(Error::TypeMismatch),
+        }
+    }
+
+    fn into_token(self) -> Token {
+        Token::String(self)
+    }
+}
+
+impl Tokenize for Address {
+    fn from_token(token: Token) -> Result<Self, Error> {
+        match token {
+            Token::Address(data) => Ok(data),
+            _ => Err(Error::TypeMismatch),
+        }
+    }
+
+    fn into_token(self) -> Token {
+        Token::Address(self)
+    }
+}
+
+impl Tokenize for U256 {
+    fn from_token(token: Token) -> Result<Self, Error> {
+        match token {
+            Token::Uint(u256) => Ok(u256),
+            _ => Err(Error::TypeMismatch),
+        }
+    }
+
+    fn into_token(self) -> Token {
+        Token::Uint(self)
+    }
+}
+
+impl Tokenize for I256 {
+    fn from_token(token: Token) -> Result<Self, Error> {
+        match token {
+            Token::Int(u256) => Ok(Self::from_raw(u256)),
+            _ => Err(Error::TypeMismatch),
+        }
+    }
+
+    fn into_token(self) -> Token {
+        Token::Int(self.into_raw())
+    }
+}
+
+impl Tokenize for TransactionHash {
+    fn from_token(token: Token) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        <[u8; 32]>::from_token(token).map(Self)
+    }
+
+    fn into_token(self) -> Token {
+        self.0.into_token()
+    }
+}
+
+macro_rules! uint_tokenize {
+    ($int: ident, $token: ident) => {
+        impl Tokenize for $int {
+            fn from_token(token: Token) -> Result<Self, Error> {
+                let u256 = match token {
+                    Token::Uint(u256) => u256,
+                    _ => return Err(Error::TypeMismatch),
+                };
+                u256.try_into().map_err(|_| Error::IntegerMismatch)
+            }
+
+            fn into_token(self) -> Token {
+                Token::Uint(self.into())
+            }
+        }
+    };
+}
+
+macro_rules! int_tokenize {
+    ($int: ident, $token: ident) => {
+        impl Tokenize for $int {
+            fn from_token(token: Token) -> Result<Self, Error> {
+                let u256 = match token {
+                    Token::Int(u256) => u256,
+                    _ => return Err(Error::TypeMismatch),
+                };
+                let i256 = I256::from_raw(u256);
+                i256.try_into().map_err(|_| Error::IntegerMismatch)
+            }
+
+            fn into_token(self) -> Token {
+                Token::Int(I256::from(self).into_raw())
+            }
+        }
+    };
+}
+
+int_tokenize!(i8, Int);
+int_tokenize!(i16, Int);
+int_tokenize!(i32, Int);
+int_tokenize!(i64, Int);
+int_tokenize!(i128, Int);
+uint_tokenize!(u8, Uint);
+uint_tokenize!(u16, Uint);
+uint_tokenize!(u32, Uint);
+uint_tokenize!(u64, Uint);
+uint_tokenize!(u128, Uint);
+
+impl Tokenize for bool {
+    fn from_token(token: Token) -> Result<Self, Error> {
+        match token {
+            Token::Bool(data) => Ok(data),
+            _ => Err(Error::TypeMismatch),
+        }
+    }
+
+    fn into_token(self) -> Token {
+        Token::Bool(self)
+    }
+}
+
+/// Marker trait for `Tokenize` types that are can tokenized to and from a `Token::Array` and
+/// `Token:FixedArray`. This is everything except `u8` because `Vec<u8>` and `[u8; n]` directly
+/// implement `Tokenize`.
+pub trait TokenizeArray: Tokenize {}
+
+macro_rules! single_tokenize_array {
+    ($($type: ty,)*) => {
+        $(
+            impl TokenizeArray for $type {}
+        )*
+    };
+}
+
+single_tokenize_array! {
+    String, Address, U256, I256, Vec<u8>, bool,
+    i8, i16, i32, i64, i128, u16, u32, u64, u128,
+}
+
+impl<T: TokenizeArray> Tokenize for Vec<T> {
+    fn from_token(token: Token) -> Result<Self, Error> {
+        match token {
+            Token::FixedArray(tokens) | Token::Array(tokens) => {
+                tokens.into_iter().map(Tokenize::from_token).collect()
+            }
+            _ => Err(Error::TypeMismatch),
+        }
+    }
+
+    fn into_token(self) -> Token {
+        Token::Array(self.into_iter().map(Tokenize::into_token).collect())
+    }
+}
+
+impl<T: TokenizeArray> TokenizeArray for Vec<T> {}
+
+macro_rules! impl_fixed_types {
+    ($num: expr) => {
+        impl<T> Tokenize for [T; $num]
+        where
+            T: TokenizeArray,
+        {
+            fn from_token(token: Token) -> Result<Self, Error>
+            where
+                Self: Sized,
+            {
+                let tokens = match token {
+                    Token::FixedArray(tokens) => tokens,
+                    _ => return Err(Error::TypeMismatch),
+                };
+                let arr_vec = tokens
+                    .into_iter()
+                    .map(T::from_token)
+                    .collect::<Result<ArrayVec<[T; $num]>, Error>>()?;
+                arr_vec
+                    .into_inner()
+                    .map_err(|_| Error::FixedArrayLengthsMismatch)
+            }
+
+            fn into_token(self) -> Token {
+                Token::FixedArray(
+                    ArrayVec::from(self)
+                        .into_iter()
+                        .map(T::into_token)
+                        .collect(),
+                )
+            }
+        }
+
+        impl<T> TokenizeArray for [T; $num] where T: TokenizeArray {}
+
+        impl Tokenize for [u8; $num] {
+            fn from_token(token: Token) -> Result<Self, Error> {
+                match token {
+                    Token::FixedBytes(bytes) => {
+                        if bytes.len() != $num {
+                            return Err(Error::TypeMismatch);
+                        }
+
+                        let mut arr = [0; $num];
+                        arr.copy_from_slice(&bytes);
+                        Ok(arr)
+                    }
+                    _ => Err(Error::TypeMismatch),
+                }
+            }
+
+            fn into_token(self) -> Token {
+                Token::FixedBytes(self.to_vec())
+            }
+        }
+
+        impl TokenizeArray for [u8; $num] {}
+    };
+}
+
+impl_fixed_types!(1);
+impl_fixed_types!(2);
+impl_fixed_types!(3);
+impl_fixed_types!(4);
+impl_fixed_types!(5);
+impl_fixed_types!(6);
+impl_fixed_types!(7);
+impl_fixed_types!(8);
+impl_fixed_types!(9);
+impl_fixed_types!(10);
+impl_fixed_types!(11);
+impl_fixed_types!(12);
+impl_fixed_types!(13);
+impl_fixed_types!(14);
+impl_fixed_types!(15);
+impl_fixed_types!(16);
+impl_fixed_types!(32);
+impl_fixed_types!(64);
+impl_fixed_types!(128);
+impl_fixed_types!(256);
+impl_fixed_types!(512);
+impl_fixed_types!(1024);
+
+macro_rules! impl_single_tokenize_for_tuple {
+    ($count: expr, $( $ty: ident : $no: tt, )*) => {
+        impl<$($ty, )*> TokenizeArray for ($($ty,)*)
+        where
+            $($ty: Tokenize,)*
+        {}
+
+        impl<$($ty, )*> Tokenize for ($($ty,)*)
+        where
+            $($ty: Tokenize,)*
+        {
+            fn from_token(token: Token) -> Result<Self, Error>
+            {
+                let tokens = match token {
+                    Token::Tuple(tokens) => tokens,
+                    _ => return Err(Error::TypeMismatch),
+                };
+                if tokens.len() != $count {
+                    return Err(Error::TupleLengthMismatch);
+                }
+                #[allow(unused_variables)]
+                #[allow(unused_mut)]
+                let mut drain = tokens.into_iter();
+                Ok(($($ty::from_token(drain.next().unwrap())?,)*))
+            }
+
+            fn into_token(self) -> Token {
+                Token::Tuple(vec![$(self.$no.into_token(),)*])
+            }
+        }
+    }
+}
+
+impl_single_tokenize_for_tuple!(0,);
+impl_single_tokenize_for_tuple!(1, A:0, );
+impl_single_tokenize_for_tuple!(2, A:0, B:1, );
+impl_single_tokenize_for_tuple!(3, A:0, B:1, C:2, );
+impl_single_tokenize_for_tuple!(4, A:0, B:1, C:2, D:3, );
+impl_single_tokenize_for_tuple!(5, A:0, B:1, C:2, D:3, E:4, );
+impl_single_tokenize_for_tuple!(6, A:0, B:1, C:2, D:3, E:4, F:5, );
+impl_single_tokenize_for_tuple!(7, A:0, B:1, C:2, D:3, E:4, F:5, G:6, );
+impl_single_tokenize_for_tuple!(8, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, );
+impl_single_tokenize_for_tuple!(9, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, );
+impl_single_tokenize_for_tuple!(10, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, );
+impl_single_tokenize_for_tuple!(11, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, );
+impl_single_tokenize_for_tuple!(12, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, );
+impl_single_tokenize_for_tuple!(13, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, );
+impl_single_tokenize_for_tuple!(14, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, );
+impl_single_tokenize_for_tuple!(15, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, );
+impl_single_tokenize_for_tuple!(16, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_single_tokenize_roundtrip<T>(value: T)
+    where
+        T: Tokenize + Clone + std::fmt::Debug + Eq,
+    {
+        assert_eq!(value, T::from_token(value.clone().into_token()).unwrap());
+    }
+
+    #[test]
+    fn single_tokenize_roundtrip() {
+        assert_single_tokenize_roundtrip(u8::MIN);
+        assert_single_tokenize_roundtrip(u8::MAX);
+        assert_single_tokenize_roundtrip(i8::MIN);
+        assert_single_tokenize_roundtrip(i8::MAX);
+        assert_single_tokenize_roundtrip(u16::MIN);
+        assert_single_tokenize_roundtrip(i16::MAX);
+        assert_single_tokenize_roundtrip(u32::MIN);
+        assert_single_tokenize_roundtrip(i32::MAX);
+        assert_single_tokenize_roundtrip(u64::MIN);
+        assert_single_tokenize_roundtrip(i64::MAX);
+        assert_single_tokenize_roundtrip(u128::MIN);
+        assert_single_tokenize_roundtrip(i128::MAX);
+        assert_single_tokenize_roundtrip(U256::zero());
+        assert_single_tokenize_roundtrip(U256::MAX);
+        assert_single_tokenize_roundtrip(I256::MIN);
+        assert_single_tokenize_roundtrip(I256::MAX);
+        assert_single_tokenize_roundtrip(false);
+        assert_single_tokenize_roundtrip(true);
+        assert_single_tokenize_roundtrip("abcd".to_string());
+        assert_single_tokenize_roundtrip(vec![0u8, 1u8, 2u8]);
+        assert_single_tokenize_roundtrip([0u8, 1u8, 2u8]);
+        assert_single_tokenize_roundtrip(Address::from_low_u64_be(42));
+        assert_single_tokenize_roundtrip(TransactionHash::from_low_u64_be(42));
+        assert_single_tokenize_roundtrip(());
+        assert_single_tokenize_roundtrip((-1i8, 1i8));
+        assert_single_tokenize_roundtrip([-1i8, 1i8]);
+    }
+
+    #[test]
+    fn tokenize_bytes() {
+        assert!(matches!([0u8].into_token(), Token::FixedBytes(_)));
+        assert!(matches!(vec![0u8].into_token(), Token::Bytes(_)));
+    }
+
+    #[test]
+    fn complex() {
+        let rust = (vec![[(0u8, 1i8)]], false);
+        let token = Token::Tuple(vec![
+            Token::Array(vec![Token::FixedArray(vec![Token::Tuple(vec![
+                Token::Uint(0.into()),
+                Token::Int(1.into()),
+            ])])]),
+            Token::Bool(false),
+        ]);
+        assert_eq!(rust.clone().into_token(), token);
+        assert_single_tokenize_roundtrip(rust);
+    }
+
+    #[test]
+    fn i256_tokenization() {
+        assert_eq!(I256::from(42).into_token(), 42i32.into_token());
+        assert_eq!(I256::minus_one().into_token(), Token::Int(U256::MAX),);
+        assert_eq!(
+            I256::from_token(Token::Int(U256::MAX)).unwrap(),
+            I256::minus_one()
+        );
+
+        assert_eq!(
+            I256::from_token(42i32.into_token()).unwrap(),
+            I256::from(42),
+        );
+    }
+}

--- a/examples/examples/abi.rs
+++ b/examples/examples/abi.rs
@@ -60,6 +60,26 @@ async fn calls(instance: &AbiTypes) {
 
     debug_call!(instance.get_array());
     debug_call!(instance.get_fixed_array());
+
+    let value = (4, 2);
+    let result = instance.abiv_2_struct(value).call().await.unwrap();
+    assert_eq!(result, value);
+
+    let value = vec![(4, 2), (5, 3)];
+    let result = instance
+        .abiv_2_array_of_struct(value.clone())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(result, value);
+
+    let value = [vec![(4, 2)], vec![(5, 3), (6, 4)], vec![]];
+    let result = instance
+        .abiv_2_array_of_array_of_struct(value.clone())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(result, value);
 }
 
 async fn events(instance: &AbiTypes) {

--- a/examples/examples/batch.rs
+++ b/examples/examples/batch.rs
@@ -30,14 +30,8 @@ async fn main() {
 
     let mut batch = CallBatch::new(web3.transport());
     let calls = vec![
-        instance
-            .balance_of(accounts[1])
-            .view()
-            .batch_call(&mut batch),
-        instance
-            .balance_of(accounts[2])
-            .view()
-            .batch_call(&mut batch),
+        instance.balance_of(accounts[1]).batch_call(&mut batch),
+        instance.balance_of(accounts[2]).batch_call(&mut batch),
     ];
     batch.execute_all(usize::MAX).await;
     for (id, call) in calls.into_iter().enumerate() {

--- a/examples/truffle/contracts/AbiTypes.sol
+++ b/examples/truffle/contracts/AbiTypes.sol
@@ -87,15 +87,15 @@ contract AbiTypes {
     return buf;
   }
 
-  event ValueUint(uint8, uint16, uint32, uint64, uint128, uint256 indexed value);
-  event ValueInt(int8, int16, int32, int64, int128, int256 indexed value);
+  event ValueUint(uint8 a, uint16 b, uint32 c, uint64 d, uint128 e, uint256 indexed value);
+  event ValueInt(int8 a, int16 b, int32 c, int64 d, int128 e, int256 indexed value);
 
   event ValueBool(bool);
 
-  event ValueBytes(string id, bytes, bytes6, address whoami);
-  event ValueArray(uint64[], int32[3]);
+  event ValueBytes(string id, bytes a, bytes6 b, address whoami);
+  event ValueArray(uint64[] a, int32[3] b);
 
-  event ValueIndexed(string indexed, uint64[] indexed);
+  event ValueIndexed(string indexed a, uint64[] indexed b);
 
   event Values(bytes32 indexed block, address sender) anonymous;
 
@@ -107,5 +107,22 @@ contract AbiTypes {
     emit ValueArray(getArray(), getFixedArray());
     emit ValueIndexed(getString(), getArray());
     emit Values(blockhash(block.number - 1), msg.sender);
+  }
+
+  // Abi v2
+
+  struct S {
+    uint8 u0;
+    uint16 u1;
+  }
+
+  function abiv2Struct(S calldata s) public pure returns (S calldata) {
+    return s;
+  }
+  function abiv2ArrayOfStruct(S[] calldata s) public view returns (S[] calldata) {
+    return s;
+  }
+  function abiv2ArrayOfArrayOfStruct(S[][3] calldata s) public view returns (S[][3] calldata) {
+    return s;
   }
 }


### PR DESCRIPTION
Edit: Ready for review, scroll down for update.

Nick pointed out that there is an ethabi fork that already supports abiv2. This PR is using this.

Where I am currently stuck is on the tokenization for web3. Web3 has several related traits https://docs.rs/web3/0.15.0/web3/contract/tokens/index.html . The trait that is usually accepted and used by ethcontract is `Tokenize`.
In my solidity example we have
```solidity
struct S {
  uint8 u0;
  uint16 u1;
}

function takeStruct(S calldata s) public view {}
```
In the abi this becomes `Tuple(uint8, uint16)` which gets turned by ethcontract in this PR into `s : (u8, u16)`.

Web3 has one trait `Tokenizable` for things that can get turned into a single `Token` and another trait `Tokenize` that turns things into `Vec<Token>`. The latter is implemented probably for convenience  so that users of web3 can pass tuples of different tokenziable things to it. This has now become problematic because it prevents tuples of Tokenizable to themself implement Tokenizable (by turning into Token::Tuple) because of ambiguous implementations. Imo the correct way to fix this is to get rid of the Tokenize trait so that we can have the mentioned tuple impl. This involves getting this merged in web3 first.
I am not sure if there is a way to achieve the same thing without touching web3. The only alternative I see is to duplicate Tokenize into ethcontract and implemented it correctly for tuples and then pass our Tokenize around instead of web3's.