### PR TITLE
Allow for BlockNumber based deployment information

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This example retrieves the entire event history of token OWL contract and prints
 the total number of events since deployment.
 
 Note the special handling of the `tokenOWLProxy` contract and how it is cast into
-a `tokenOWL` instance using Contract's `with_transaction` feature.
+a `tokenOWL` instance using Contract's `with_deployment_info` feature.
 
 ```sh
 export INFURA_PROJECT_ID="Infura project ID"

--- a/ethcontract-common/src/lib.rs
+++ b/ethcontract-common/src/lib.rs
@@ -13,5 +13,28 @@ pub use crate::abiext::FunctionExt;
 pub use crate::bytecode::Bytecode;
 pub use crate::truffle::Artifact;
 pub use ethabi::{self as abi, Contract as Abi};
+use serde::Deserialize;
 pub use web3::types::Address;
 pub use web3::types::H256 as TransactionHash;
+
+/// Information about when a contract instance was deployed
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum DeploymentInformation {
+    /// The block at which the contract was deployed
+    BlockNumber(u64),
+    /// The transaction hash at which the contract was deployed
+    TransactionHash(TransactionHash),
+}
+
+impl From<u64> for DeploymentInformation {
+    fn from(block: u64) -> Self {
+        Self::BlockNumber(block)
+    }
+}
+
+impl From<TransactionHash> for DeploymentInformation {
+    fn from(hash: TransactionHash) -> Self {
+        Self::TransactionHash(hash)
+    }
+}

--- a/ethcontract-common/src/truffle.rs
+++ b/ethcontract-common/src/truffle.rs
@@ -1,13 +1,13 @@
 //! Module for reading and examining data produced by truffle.
 
-use crate::bytecode::Bytecode;
 use crate::errors::ArtifactError;
+use crate::{bytecode::Bytecode, DeploymentInformation};
 use ethabi::Contract as Abi;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
-use web3::types::{Address, H256};
+use web3::types::Address;
 
 /// Represents a truffle artifact.
 #[derive(Clone, Debug, Deserialize)]
@@ -74,7 +74,7 @@ pub struct Network {
     pub address: Address,
     /// The hash of the transaction that deployed the contract on this network.
     #[serde(rename = "transactionHash")]
-    pub transaction_hash: Option<H256>,
+    pub deployment_information: Option<DeploymentInformation>,
 }
 
 /// A contract's documentation.

--- a/ethcontract-generate/src/contract.rs
+++ b/ethcontract-generate/src/contract.rs
@@ -13,7 +13,7 @@ mod types;
 use crate::util;
 use crate::Args;
 use anyhow::{anyhow, Context as _, Result};
-use ethcontract_common::{Address, Artifact, TransactionHash};
+use ethcontract_common::{Address, Artifact, DeploymentInformation};
 use inflector::Inflector;
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
@@ -22,7 +22,7 @@ use syn::{Path, Visibility};
 
 pub(crate) struct Deployment {
     pub address: Address,
-    pub transaction_hash: Option<TransactionHash>,
+    pub deployment_information: Option<DeploymentInformation>,
 }
 
 /// Internal shared context for generating smart contract bindings.

--- a/ethcontract-generate/src/contract/deployment.rs
+++ b/ethcontract-generate/src/contract/deployment.rs
@@ -158,7 +158,7 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
                 transaction_hash: self::ethcontract::H256,
                 _: Self::Context,
             ) -> Self {
-                Self::with_transaction(&web3, address, Some(transaction_hash))
+                Self::with_deployment_info(&web3, address, Some(transaction_hash.into()))
             }
         }
     })

--- a/ethcontract-generate/src/contract/events.rs
+++ b/ethcontract-generate/src/contract/events.rs
@@ -401,7 +401,7 @@ fn expand_all_events(cx: &Context) -> TokenStream {
                 self::ethcontract::dyns::DynAllEventsBuilder::new(
                     self.raw_instance().web3(),
                     self.address(),
-                    self.transaction_hash(),
+                    self.deployment_information(),
                 )
             }
         }

--- a/ethcontract-generate/src/lib.rs
+++ b/ethcontract-generate/src/lib.rs
@@ -19,6 +19,7 @@ pub use crate::source::Source;
 pub use crate::util::parse_address;
 use anyhow::Result;
 use contract::Deployment;
+use ethcontract_common::DeploymentInformation;
 pub use ethcontract_common::{Address, TransactionHash};
 use proc_macro2::TokenStream;
 use std::collections::HashMap;
@@ -156,7 +157,7 @@ impl Builder {
     }
 
     /// Manually adds specifies the deployed address and deployment transaction
-    /// hash of a contract for a given network. Note that manually specified
+    /// hash or block of a contract for a given network. Note that manually specified
     /// deployments take precedence over deployments in the Truffle artifact (in
     /// the `networks` property of the artifact).
     ///
@@ -168,11 +169,11 @@ impl Builder {
         mut self,
         network_id: u32,
         address: Address,
-        transaction_hash: Option<TransactionHash>,
+        deployment_information: Option<DeploymentInformation>,
     ) -> Self {
         let deployment = Deployment {
             address,
-            transaction_hash,
+            deployment_information,
         };
         self.args.deployments.insert(network_id, deployment);
         self

--- a/examples/examples/past_events.rs
+++ b/examples/examples/past_events.rs
@@ -1,4 +1,4 @@
-use ethcontract::prelude::*;
+use ethcontract::{common::DeploymentInformation, prelude::*};
 use futures::TryStreamExt as _;
 use std::env;
 
@@ -20,8 +20,11 @@ async fn main() {
         .expect("locating deployed contract failed");
 
     // Casting proxy token into actual token
-    let owl_token =
-        TokenOWL::with_transaction(&web3, owl_proxy.address(), owl_proxy.transaction_hash());
+    let owl_token = TokenOWL::with_deployment_info(
+        &web3,
+        owl_proxy.address(),
+        Some(DeploymentInformation::BlockNumber(12063584)),
+    );
     println!("Using OWL token at {:?}", owl_token.address());
     println!("Retrieving all past events (this could take a while)...");
     let event_history_stream = owl_token

--- a/examples/examples/rinkeby.rs
+++ b/examples/examples/rinkeby.rs
@@ -37,7 +37,7 @@ async fn main() {
     println!(
         "Using contract at {:?} deployed with transaction {:?}",
         instance.address(),
-        instance.transaction_hash(),
+        instance.deployment_information(),
     );
 
     println!(

--- a/examples/generate/build.rs
+++ b/examples/generate/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     Builder::new("../truffle/build/contracts/RustCoin.json")
-        .add_deployment(42, Address::zero(), Some(TransactionHash::zero()))
+        .add_deployment(42, Address::zero(), Some(TransactionHash::zero().into()))
         .generate()
         .unwrap()
         .write_to_file(Path::new(&dest).join("rust_coin.rs"))


### PR DESCRIPTION
[Geth v1.10.0](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.0) changed their data retention policy to not include transaction inclusion records that are older than one year:

> Geth 1.10.0 contains some changes which remove unnecessary data in the blockchain database. In particular, Geth no longer keeps transaction inclusion info for all transactions, and instead limits the storage of inclusion records to one year. 

This is a problem for the https://github.com/gnosis/dex-services codebase, as it depends on contracts that have been deployed more [than a year ago](https://rinkeby.etherscan.io/tx/0xc5bf4f48747093a79b623c2a2392ccbdb73a3d788e7d1f0f53f640ea18496d90).

The problem in particular happens in `AllEventsBuilder::query_paginated` when we try to map the deployment transaction hash into a block number to decide the earliest point from which to query events.

This PR suggests a fix that changes the deployment information from being purely tx hash based to an enum that can be either a tx hash or a block number. This will allow us to override the deployment hash with the corresponding block number and avoid a `transaction_receipt` RPC call for old contracts.

### Test Plan
Unit tests and manually tested that the override works in `past_events` example.