### PR TITLE
Implement Tokenize for BytesArray & update generator

### DIFF
--- a/ethcontract-common/src/lib.rs
+++ b/ethcontract-common/src/lib.rs
@@ -14,8 +14,8 @@ pub use crate::bytecode::Bytecode;
 pub use crate::truffle::Artifact;
 pub use ethabi_fork_ethcontract::{self as abi, Contract as Abi};
 use serde::Deserialize;
-pub use web3::types::Address;
 pub use web3::types::H256 as TransactionHash;
+pub use web3::types::{Address, BytesArray};
 
 /// Information about when a contract instance was deployed
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]

--- a/ethcontract-generate/src/contract/types.rs
+++ b/ethcontract-generate/src/contract/types.rs
@@ -27,10 +27,13 @@ pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
         },
         ParamType::Bool => Ok(quote! { bool }),
         ParamType::String => Ok(quote! { String }),
-        ParamType::Array(t) => {
-            let inner = expand(t)?;
-            Ok(quote! { Vec<#inner> })
-        }
+        ParamType::Array(t) => match **t {
+            ParamType::Uint(8) => Ok(quote! { self::ethcontract::BytesArray }),
+            _ => {
+                let inner = expand(t)?;
+                Ok(quote! { Vec<#inner> })
+            }
+        },
         ParamType::FixedBytes(n) => {
             // TODO(nlordell): what is the performance impact of returning large
             //   `FixedBytes` and `FixedArray`s with `web3`?

--- a/ethcontract-generate/src/lib.rs
+++ b/ethcontract-generate/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::util::parse_address;
 use anyhow::Result;
 use contract::Deployment;
 use ethcontract_common::DeploymentInformation;
-pub use ethcontract_common::{Address, TransactionHash};
+pub use ethcontract_common::{Address, BytesArray, TransactionHash};
 use proc_macro2::TokenStream;
 use std::collections::HashMap;
 use std::fs::File;

--- a/ethcontract/src/lib.rs
+++ b/ethcontract/src/lib.rs
@@ -126,7 +126,9 @@ pub mod prelude {
     pub use web3::api::Web3;
     #[cfg(feature = "http")]
     pub use web3::transports::Http;
-    pub use web3::types::{Address, BlockId, BlockNumber, TransactionCondition, H160, H256, U256};
+    pub use web3::types::{
+        Address, BlockId, BlockNumber, BytesArray, TransactionCondition, H160, H256, U256,
+    };
 }
 
 pub mod dyns {


### PR DESCRIPTION
The contract call could return `uint8[]` instead of `bytes`, but `uint8[]` is generated as `Vec<u8>` and will always be used as `Token::Bytes` and will always return `Error::TypeMismatch`: https://github.com/gnosis/ethcontract-rs/blob/main/ethcontract/src/tokens.rs#L63-L77

The `uint8[]` in this PR will be generated as `web3::BytesArray` with `Tokenize` implemented.