### PR TITLE
Allow arrays of u8 by moving bytes to a wrapper type

### DIFF
--- a/ethcontract-generate/src/contract/types.rs
+++ b/ethcontract-generate/src/contract/types.rs
@@ -6,7 +6,7 @@ use quote::quote;
 pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
     match kind {
         ParamType::Address => Ok(quote! { self::ethcontract::Address }),
-        ParamType::Bytes => Ok(quote! { Vec<u8> }),
+        ParamType::Bytes => Ok(quote! { self::ethcontract::tokens::Bytes<Vec<u8>> }),
         ParamType::Int(n) => match n / 8 {
             1 => Ok(quote! { i8 }),
             2 => Ok(quote! { i16 }),
@@ -35,7 +35,7 @@ pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
             // TODO(nlordell): what is the performance impact of returning large
             //   `FixedBytes` and `FixedArray`s with `web3`?
             let size = Literal::usize_unsuffixed(*n);
-            Ok(quote! { [u8; #size] })
+            Ok(quote! { self::ethcontract::tokens::Bytes<[u8; #size]> })
         }
         ParamType::FixedArray(t, n) => {
             // TODO(nlordell): see above

--- a/ethcontract/src/lib.rs
+++ b/ethcontract/src/lib.rs
@@ -121,6 +121,7 @@ pub mod prelude {
     pub use crate::contract::{Event, EventMetadata, EventStatus, RawLog, StreamEvent, Topic};
     pub use crate::int::I256;
     pub use crate::secret::{Password, PrivateKey};
+    pub use crate::tokens::Bytes;
     pub use crate::transaction::{Account, GasPrice};
     pub use ethcontract_common::TransactionHash;
     pub use web3::api::Web3;

--- a/examples/examples/abi.rs
+++ b/examples/examples/abi.rs
@@ -80,6 +80,33 @@ async fn calls(instance: &AbiTypes) {
         .await
         .unwrap();
     assert_eq!(result, value);
+
+    let vec = vec![1u8, 2, 3];
+    let array = [1u8, 2, 3];
+    let result = instance
+        .roundtrip_u8_array(vec.clone())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(result, vec);
+    let result = instance
+        .roundtrip_fixed_u8_array(array)
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(result, array);
+    let result = instance
+        .roundtrip_bytes(Bytes(vec.clone()))
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(result.0, vec);
+    let result = instance
+        .roundtrip_fixed_bytes(Bytes(array))
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(result.0, array);
 }
 
 async fn events(instance: &AbiTypes) {

--- a/examples/truffle/contracts/AbiTypes.sol
+++ b/examples/truffle/contracts/AbiTypes.sol
@@ -47,7 +47,6 @@ contract AbiTypes {
   function getBool() public view returns (bool) {
     return this.getU256() & 0x1 != 0;
   }
-
   function getBytes() public view returns (bytes memory) {
     return abi.encodePacked(this.getU32());
   }
@@ -125,4 +124,18 @@ contract AbiTypes {
   function abiv2ArrayOfArrayOfStruct(S[][3] calldata s) public view returns (S[][3] calldata) {
     return s;
   }
+
+  function roundtripBytes(bytes calldata a) public view returns (bytes calldata) {
+    return a;
+  }
+  function roundtripFixedBytes(bytes3 a) public view returns (bytes3) {
+    return a;
+  }
+  function roundtripU8Array(uint8[] calldata a) public view returns (uint8[] calldata) {
+    return a;
+  }
+  function roundtripFixedU8Array(uint8[3] calldata a) public view returns (uint8[3] calldata) {
+    return a;
+  }
+
 }


### PR DESCRIPTION
By wrapping Bytes and FixedBytes we make the code and api more consistent because Vec<u8> is no longer a special case. Fixes not being able to use Array of uint8 in abi.