### PR TITLE
Remove Unpin bounds

### DIFF
--- a/ethcontract-generate/src/contract/common.rs
+++ b/ethcontract-generate/src/contract/common.rs
@@ -72,7 +72,7 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
             where
                 F: std::future::Future<
                        Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + Unpin + 'static,
+                   > + Send + 'static,
                 T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 Contract::with_deployment_info(web3, address, None)
@@ -95,7 +95,7 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
             where
                 F: std::future::Future<
                        Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + Unpin + 'static,
+                   > + Send + 'static,
                 T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 use self::ethcontract::Instance;

--- a/ethcontract-generate/src/contract/deployment.rs
+++ b/ethcontract-generate/src/contract/deployment.rs
@@ -34,7 +34,7 @@ fn expand_deployed(cx: &Context) -> TokenStream {
             where
                 F: std::future::Future<
                        Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + Unpin + 'static,
+                   > + Send + 'static,
                 T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 use self::ethcontract::{Instance, Web3};
@@ -124,7 +124,7 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
             where
                 F: std::future::Future<
                        Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + Unpin + 'static,
+                   > + Send + 'static,
                 T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
             {
                 use self::ethcontract::dyns::DynTransport;

--- a/ethcontract/src/transport.rs
+++ b/ethcontract/src/transport.rs
@@ -34,7 +34,7 @@ trait TransportBoxed: Debug {
 
 impl<F, T> TransportBoxed for T
 where
-    F: Future<Output = Result<Value, Web3Error>> + Send + Unpin + 'static,
+    F: Future<Output = Result<Value, Web3Error>> + Send + 'static,
     T: Transport<Out = F>,
 {
     #[inline(always)]
@@ -64,7 +64,7 @@ impl DynTransport {
     /// Wrap a `Transport` in a `DynTransport`
     pub fn new<F, T>(inner: T) -> Self
     where
-        F: Future<Output = Result<Value, Web3Error>> + Send + Unpin + 'static,
+        F: Future<Output = Result<Value, Web3Error>> + Send + 'static,
         T: Transport<Out = F> + Sync + Send + 'static,
     {
         let inner_ref: &dyn Any = &inner;


### PR DESCRIPTION
I believe these were required back when web3's Transport had to use
Unpin futures which is no longer the case.