### PR TITLE
Evict cache in attempt to fix CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -35,6 +35,8 @@ jobs:
           components: rustfmt, clippy
           default: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: key-to-evict-cache
       - run: cargo fmt -- --check
       - run: cd examples/truffle && yarn --frozen-lockfile && yarn build
       # Can't use --all-features here because web3 has mutually exclusive features.

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.51.0
+          - rust: 1.52.1
             examples: false
             continue-on-error: false
           - rust: stable
@@ -35,8 +35,6 @@ jobs:
           components: rustfmt, clippy
           default: true
       - uses: Swatinem/rust-cache@v1
-        with:
-          key: key-to-evict-cache
       - run: cargo fmt -- --check
       - run: cd examples/truffle && yarn --frozen-lockfile && yarn build
       # Can't use --all-features here because web3 has mutually exclusive features.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/gnosis/ethcontract-rs.svg?branch=main)](https://travis-ci.org/gnosis/ethcontract-rs)
 [![Crates.io](https://img.shields.io/crates/v/ethcontract.svg)](https://crates.io/crates/ethcontract)
 [![Docs.rs](https://docs.rs/ethcontract/badge.svg)](https://docs.rs/ethcontract)
-[![Rustc Version](https://img.shields.io/badge/rustc-1.47+-lightgray.svg)](https://blog.rust-lang.org/2019/12/19/Rust-1.47.0.html)
+[![Rustc Version](https://img.shields.io/badge/rustc-1.52+-lightgray.svg)](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html)
 
 # `ethcontract-rs`
 
@@ -30,7 +30,7 @@ for interacting with contract functions in a type-safe way.
 
 ### Minimum Supported Rust Version
 
-The minimum supported Rust version is 1.42.
+The minimum supported Rust version is 1.52.
 
 ## Generator API
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/gnosis/ethcontract-rs.svg?branch=main)](https://travis-ci.org/gnosis/ethcontract-rs)
 [![Crates.io](https://img.shields.io/crates/v/ethcontract.svg)](https://crates.io/crates/ethcontract)
 [![Docs.rs](https://docs.rs/ethcontract/badge.svg)](https://docs.rs/ethcontract)
-[![Rustc Version](https://img.shields.io/badge/rustc-1.52+-lightgray.svg)](https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html)
+[![Rustc Version](https://img.shields.io/badge/rustc-1.52+-lightgray.svg)](https://blog.rust-lang.org/2021/05/06/Rust-1.52.1.html)
 
 # `ethcontract-rs`
 


### PR DESCRIPTION
For some reason CI succeeds on PRs but not on main. I suspect the reason is cache related. So with this PR I am changing the compiler version which should evict the cache.
Also updates the minimum supported rust version in the readme which was behind. It's not great to change the minimum version just to fix CI but we have also always bumped it when needed so should be fine. And we could go down a version again after the cache got cleared if we wanted to.