### PR TITLE
Use polling instead of filters to wait for tx confirmation

### DIFF
--- a/ethcontract/src/transaction.rs
+++ b/ethcontract/src/transaction.rs
@@ -294,8 +294,7 @@ mod tests {
         transport.add_response(json!(tx_hash));
         transport.add_response(json!("0x1"));
         transport.add_response(json!(null));
-        transport.add_response(json!("0xf0"));
-        transport.add_response(json!([H256::repeat_byte(2), H256::repeat_byte(3)]));
+        transport.add_response(json!("0x2"));
         transport.add_response(json!("0x3"));
         transport.add_response(json!({
             "transactionHash": tx_hash,
@@ -332,8 +331,7 @@ mod tests {
         transport.assert_request("eth_sendRawTransaction", &[json!(tx_raw)]);
         transport.assert_request("eth_blockNumber", &[]);
         transport.assert_request("eth_getTransactionReceipt", &[json!(tx_hash)]);
-        transport.assert_request("eth_newBlockFilter", &[]);
-        transport.assert_request("eth_getFilterChanges", &[json!("0xf0")]);
+        transport.assert_request("eth_blockNumber", &[]);
         transport.assert_request("eth_blockNumber", &[]);
         transport.assert_request("eth_getTransactionReceipt", &[json!(tx_hash)]);
         transport.assert_no_more_requests();

--- a/ethcontract/src/transaction/confirm.rs
+++ b/ethcontract/src/transaction/confirm.rs
@@ -8,7 +8,6 @@
 
 use crate::errors::ExecutionError;
 use crate::transaction::TransactionResult;
-use futures::StreamExt as _;
 use futures_timer::Delay;
 use std::time::Duration;
 use web3::api::Web3;


### PR DESCRIPTION
There's a race condition. If transaction gets mined after we fetch latest block number, but before we create a filter, then we wait for more blocks than necessary. If new blocks are not generated (i.e. dev setup or testchains with low activity), waiting for transaction may hang.

We attempt to remedy this issue by switching entirely to polling for block numbers. In theory, this should also decrease node's load. A potential downside is that confirmation times may increase. That is, we now poll node every seven seconds instead of confirming transaction immediately after the target block was mined. We will fix that later by introducing exponential backoff to polling mechanism — see #534.

Fix #533.