### PR TITLE
Make signed transaction's hash available

### DIFF
--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -48,4 +48,5 @@ web3 = { version = "0.16", default-features = false, features = ["signing"] }
 zeroize = "1.1"
 
 [dev-dependencies]
+hex-literal = "0.3"
 tokio = { version = "1.6", features = ["macros"] }

--- a/ethcontract/src/errors.rs
+++ b/ethcontract/src/errors.rs
@@ -108,6 +108,10 @@ pub enum ExecutionError {
     /// A tokenization related error.
     #[error("tokenization error: {0}")]
     Tokenization(#[from] crate::tokens::Error),
+
+    /// Unexpected transaction hash
+    #[error("transaction hash returned from node when sending raw transaction does not match expected hash")]
+    UnexpectedTransactionHash,
 }
 
 impl From<Web3Error> for ExecutionError {

--- a/ethcontract/src/transaction.rs
+++ b/ethcontract/src/transaction.rs
@@ -210,6 +210,7 @@ mod tests {
     use super::*;
     use crate::errors::ExecutionError;
     use crate::test::prelude::*;
+    use hex_literal::hex;
     use web3::types::{H2048, H256};
 
     #[test]
@@ -289,7 +290,9 @@ mod tests {
 
         let key = key!("0x0102030405060708091011121314151617181920212223242526272829303132");
         let chain_id = 77777;
-        let tx_hash = H256::repeat_byte(0xff);
+        let tx_hash = H256(hex!(
+            "248988e44deaff5162c3f998a8b1f510862366a68ef4339dff6ec89e120a6c19"
+        ));
 
         transport.add_response(json!(tx_hash));
         transport.add_response(json!("0x1"));
@@ -344,7 +347,9 @@ mod tests {
 
         let key = key!("0x0102030405060708091011121314151617181920212223242526272829303132");
         let chain_id = 77777;
-        let tx_hash = H256::repeat_byte(0xff);
+        let tx_hash = H256(hex!(
+            "248988e44deaff5162c3f998a8b1f510862366a68ef4339dff6ec89e120a6c19"
+        ));
 
         transport.add_response(json!(tx_hash));
         transport.add_response(json!("0x1"));


### PR DESCRIPTION
Motivation is that to implement the archerdao integration I need access to the transaction hash. I would like to continue using ethcontract to do signing and this data is already available.

### Test Plan
adapted tests