### PR TITLE
Switch to released ethabi

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -12,7 +12,7 @@ Common types for ethcontract-rs runtime and proc macro.
 """
 
 [dependencies]
-ethabi = { git = "https://github.com/taminomara/ethabi", branch = "serialize-contracts" }
+ethabi = "14.1.0"
 hex = "0.4"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Replace temporary dev dependency with the released crate version