### PR TITLE
Enable dependabot updates for hardhat project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,12 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: increase
     rebase-strategy: disabled
+  - package-ecosystem: npm
+    directory: "/examples/hardhat"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    rebase-strategy: disabled


### PR DESCRIPTION
I'm not sure if we need this. We don't build hardhat project regularly, because all artifacts are committed to the repo.