### PR TITLE
Remove generic in impl parameter

### DIFF
--- a/ethcontract-generate/src/lib.rs
+++ b/ethcontract-generate/src/lib.rs
@@ -85,20 +85,20 @@ impl ContractBuilder {
 
     /// Sets the crate name for the runtime crate. This setting is usually only
     /// needed if the crate was renamed in the Cargo manifest.
-    pub fn runtime_crate_name<S>(mut self, name: impl Into<String>) -> Self {
+    pub fn runtime_crate_name(mut self, name: impl Into<String>) -> Self {
         self.runtime_crate_name = name.into();
         self
     }
 
     /// Sets an optional visibility modifier for the generated module and
     /// contract re-export.
-    pub fn visibility_modifier<S>(mut self, vis: impl Into<String>) -> Self {
+    pub fn visibility_modifier(mut self, vis: impl Into<String>) -> Self {
         self.visibility_modifier = Some(vis.into());
         self
     }
 
     /// Sets the optional contract module name override.
-    pub fn contract_mod_override<S>(mut self, name: impl Into<String>) -> Self {
+    pub fn contract_mod_override(mut self, name: impl Into<String>) -> Self {
         self.contract_mod_override = Some(name.into());
         self
     }
@@ -106,7 +106,7 @@ impl ContractBuilder {
     /// Sets the optional contract name override. This setting is needed when
     /// using an artifact JSON source that does not provide a contract name such
     /// as Etherscan.
-    pub fn contract_name_override<S>(mut self, name: impl Into<String>) -> Self {
+    pub fn contract_name_override(mut self, name: impl Into<String>) -> Self {
         self.contract_name_override = Some(name.into());
         self
     }


### PR DESCRIPTION
This was a probably a leftover from an earlier refactoring. The
parameter is already `impl Into<String>` so the generic type is not
used.

This has the side effect of making the function uncallable because the compiler is confused about mixing this generic type with the impl type (or maybe just a bad error message). Will report it to the rust compiler.
