### PR TITLE
Move convenience utilities for tests to a public module

### DIFF
--- a/ethcontract-mock/src/lib.rs
+++ b/ethcontract-mock/src/lib.rs
@@ -232,6 +232,7 @@ pub use ethcontract::contract::Signature;
 mod details;
 mod predicate;
 mod range;
+pub mod utils;
 
 #[cfg(test)]
 mod test;

--- a/ethcontract-mock/src/test/mod.rs
+++ b/ethcontract-mock/src/test/mod.rs
@@ -62,6 +62,7 @@
 //!
 //! - confirmations plays nicely with tx.confirmations
 
+use crate::utils::*;
 use crate::{Contract, Mock};
 use ethcontract::dyns::DynWeb3;
 use ethcontract::prelude::*;
@@ -78,18 +79,6 @@ mod eth_transaction_count;
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
 ethcontract::contract!("examples/truffle/build/contracts/IERC20.json");
-
-fn address_for(who: &str) -> Address {
-    account_for(who).address()
-}
-
-fn account_for(who: &str) -> Account {
-    use ethcontract::web3::signing::keccak256;
-    Account::Offline(
-        PrivateKey::from_raw(keccak256(who.as_bytes())).unwrap(),
-        None,
-    )
-}
 
 fn setup() -> (Mock, DynWeb3, Contract, IERC20) {
     let mock = Mock::new(1234);

--- a/ethcontract-mock/src/utils.rs
+++ b/ethcontract-mock/src/utils.rs
@@ -1,0 +1,41 @@
+//! Convenience utilities for tests.
+
+use ethcontract::{Account, Address, PrivateKey};
+
+/// Generate public address by hashing the given string.
+///
+/// # Safety
+///
+/// This function is intended for tests and should not be used in production.
+///
+/// # Examples
+///
+/// ```
+/// # use ethcontract_mock::utils::address_for;
+/// let address = address_for("Alice");
+/// # assert_eq!(address, "0xbf0b5a4099f0bf6c8bc4252ebec548bae95602ea".parse().unwrap());
+/// ```
+pub fn address_for(who: &str) -> Address {
+    account_for(who).address()
+}
+
+/// Generate a private key by hashing the given string.
+///
+/// # Safety
+///
+/// This function is intended for tests and should not be used in production.
+///
+/// # Examples
+///
+/// ```
+/// # use ethcontract_mock::utils::account_for;
+/// let account = account_for("Bob");
+/// # assert_eq!(account.address(), "0x4dba461ca9342f4a6cf942abd7eacf8ae259108c".parse().unwrap());
+/// ```
+pub fn account_for(who: &str) -> Account {
+    use ethcontract::web3::signing::keccak256;
+    Account::Offline(
+        PrivateKey::from_raw(keccak256(who.as_bytes())).unwrap(),
+        None,
+    )
+}


### PR DESCRIPTION
Instead of re-implementing these small functions in every crate, we could have them here.