### PR TITLE
Fix bump script for OSX

### DIFF
--- a/ci/bump.sh
+++ b/ci/bump.sh
@@ -65,5 +65,9 @@ function msg {
 msg "Updating Cargo manifests with new version '$version':"
 for manifest in ethcontract*/Cargo.toml; do
 	msg "  - $manifest"
-	sed -i -E -e 's/^((ethcontract-[a-z]+ = \{ )?version) = "[0-9\.]+"/\1 = "'"$version"'"/g' "$manifest"
+	if [[ $(uname) == Darwin ]]; then
+		sed -i '' -E -e 's/^((ethcontract(-[a-z]+)? = \{ )?version) = "[0-9\.]+"/\1 = "'"$version"'"/g' "$manifest"
+	else
+		sed -i -E -e 's/^((ethcontract(-[a-z]+)? = \{ )?version) = "[0-9\.]+"/\1 = "'"$version"'"/g' "$manifest"
+	fi
 done


### PR DESCRIPTION
OSX `sed` is not compatible with GNU `sed`. It has different syntax for `-i` option. See this [stackoverflow] question.

[stackoverflow]: https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux