### PR TITLE
Implement `BatchTransport` for `DynTransport`

### DIFF
--- a/ethcontract-generate/src/generate/common.rs
+++ b/ethcontract-generate/src/generate/common.rs
@@ -68,19 +68,38 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
             ///
             /// Note that this does not verify that a contract with a matching
             /// `Abi` is actually deployed at the given address.
-            pub fn at<F, T>(
+            pub fn at<F, B, T>(
                 web3: &self::ethcontract::web3::api::Web3<T>,
                 address: self::ethcontract::Address,
             ) -> Self
             where
                 F: std::future::Future<
-                       Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + 'static,
-                T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
+                        Output = Result<
+                            self::ethcontract::json::Value,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                B: std::future::Future<
+                        Output = Result<
+                            Vec<
+                                Result<
+                                    self::ethcontract::json::Value,
+                                    self::ethcontract::web3::Error,
+                                >,
+                            >,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                T: self::ethcontract::web3::Transport<Out = F>
+                    + self::ethcontract::web3::BatchTransport<Batch = B>
+                    + Send
+                    + Sync
+                    + 'static,
             {
                 Contract::with_deployment_info(web3, address, None)
             }
-
 
             /// Creates a new contract instance with the specified `web3` provider with
             /// the given `Abi` at the given `Address` and an optional transaction hash.
@@ -90,16 +109,36 @@ pub(crate) fn expand(cx: &Context) -> TokenStream {
             /// Note that this does not verify that a contract with a matching `Abi` is
             /// actually deployed at the given address nor that the transaction hash,
             /// when provided, is actually for this contract deployment.
-            pub fn with_deployment_info<F, T>(
+            pub fn with_deployment_info<F, B, T>(
                 web3: &self::ethcontract::web3::api::Web3<T>,
                 address: self::ethcontract::Address,
                 deployment_information: Option<ethcontract::common::DeploymentInformation>,
             ) -> Self
             where
                 F: std::future::Future<
-                       Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + 'static,
-                T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
+                        Output = Result<
+                            self::ethcontract::json::Value,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                B: std::future::Future<
+                        Output = Result<
+                            Vec<
+                                Result<
+                                    self::ethcontract::json::Value,
+                                    self::ethcontract::web3::Error,
+                                >,
+                            >,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                T: self::ethcontract::web3::Transport<Out = F>
+                    + self::ethcontract::web3::BatchTransport<Batch = B>
+                    + Send
+                    + Sync
+                    + 'static,
             {
                 use self::ethcontract::Instance;
                 use self::ethcontract::transport::DynTransport;

--- a/ethcontract-generate/src/generate/deployment.rs
+++ b/ethcontract-generate/src/generate/deployment.rs
@@ -28,14 +28,34 @@ fn expand_deployed(cx: &Context) -> TokenStream {
             ///
             /// Note that this does not verify that a contract with a matching
             /// `Abi` is actually deployed at the given address.
-            pub async fn deployed<F, T>(
+            pub async fn deployed<F, B, T>(
                 web3: &self::ethcontract::web3::api::Web3<T>,
             ) -> Result<Self, self::ethcontract::errors::DeployError>
             where
                 F: std::future::Future<
-                       Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + 'static,
-                T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
+                        Output = Result<
+                            self::ethcontract::json::Value,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                B: std::future::Future<
+                        Output = Result<
+                            Vec<
+                                Result<
+                                    self::ethcontract::json::Value,
+                                    self::ethcontract::web3::Error,
+                                >,
+                            >,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                T: self::ethcontract::web3::Transport<Out = F>
+                    + self::ethcontract::web3::BatchTransport<Batch = B>
+                    + Send
+                    + Sync
+                    + 'static,
             {
                 use self::ethcontract::{Instance, Web3};
                 use self::ethcontract::transport::DynTransport;
@@ -119,14 +139,34 @@ fn expand_deploy(cx: &Context) -> Result<TokenStream> {
         impl Contract {
             #doc
             #[allow(clippy::too_many_arguments)]
-            pub fn builder<F, T>(
+            pub fn builder<F, B, T>(
                 web3: &self::ethcontract::web3::api::Web3<T> #lib_input #input ,
             ) -> self::ethcontract::dyns::DynDeployBuilder<Self>
             where
                 F: std::future::Future<
-                       Output = Result<self::ethcontract::json::Value, self::ethcontract::web3::Error>
-                   > + Send + 'static,
-                T: self::ethcontract::web3::Transport<Out = F> + Send + Sync + 'static,
+                        Output = Result<
+                            self::ethcontract::json::Value,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                B: std::future::Future<
+                        Output = Result<
+                            Vec<
+                                Result<
+                                    self::ethcontract::json::Value,
+                                    self::ethcontract::web3::Error,
+                                >,
+                            >,
+                            self::ethcontract::web3::Error,
+                        >,
+                    > + Send
+                    + 'static,
+                T: self::ethcontract::web3::Transport<Out = F>
+                    + self::ethcontract::web3::BatchTransport<Batch = B>
+                    + Send
+                    + Sync
+                    + 'static,
             {
                 use self::ethcontract::dyns::DynTransport;
                 use self::ethcontract::contract::DeployBuilder;

--- a/ethcontract-mock/src/details/mod.rs
+++ b/ethcontract-mock/src/details/mod.rs
@@ -15,7 +15,7 @@ use ethcontract::tokens::Tokenize;
 use ethcontract::web3::types::{
     Bytes, CallRequest, TransactionReceipt, TransactionRequest, U256, U64,
 };
-use ethcontract::web3::{helpers, Error, RequestId, Transport};
+use ethcontract::web3::{helpers, BatchTransport, Error, RequestId, Transport};
 use ethcontract::{Address, BlockNumber, H160, H256};
 use parse::Parser;
 use sign::verify;
@@ -362,6 +362,28 @@ impl Transport for MockTransport {
 
     /// Executes a prepared RPC call.
     fn send(&self, _: RequestId, request: Call) -> Self::Out {
+        ready(self.process_call(request))
+    }
+}
+
+impl BatchTransport for MockTransport {
+    type Batch = std::future::Ready<Result<Vec<Result<Value, Error>>, Error>>;
+
+    fn send_batch<T>(&self, requests: T) -> Self::Batch
+    where
+        T: IntoIterator<Item = (RequestId, Call)>,
+    {
+        let mut results = Vec::new();
+        for (_, call) in requests.into_iter() {
+            results.push(self.process_call(call));
+        }
+
+        ready(Ok(results))
+    }
+}
+
+impl MockTransport {
+    fn process_call(&self, request: Call) -> Result<Value, Error> {
         let MethodCall { method, params, .. } = match request {
             Call::MethodCall(method_call) => method_call,
             Call::Notification(_) => panic!("rpc notifications are not supported"),
@@ -414,11 +436,9 @@ impl Transport for MockTransport {
             unsupported => panic!("mock node does not support rpc method {:?}", unsupported),
         };
 
-        ready(result)
+        result
     }
-}
 
-impl MockTransport {
     fn block_number(&self, args: Parser) -> Result<Value, Error> {
         args.done();
 

--- a/ethcontract-mock/src/test/batch.rs
+++ b/ethcontract-mock/src/test/batch.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+#[tokio::test]
+async fn batch_ok() -> Result {
+    let (_, _, contract, instance) = setup();
+
+    let mut seq = mockall::Sequence::new();
+
+    contract
+        .expect(ERC20::signatures().name())
+        .once()
+        .in_sequence(&mut seq)
+        .returns("WrappedEther".into());
+    contract
+        .expect(ERC20::signatures().symbol())
+        .once()
+        .in_sequence(&mut seq)
+        .returns("WETH".into());
+    contract
+        .expect(ERC20::signatures().decimals())
+        .once()
+        .returns(18)
+        .in_sequence(&mut seq);
+    contract
+        .expect(ERC20::signatures().total_supply())
+        .once()
+        .in_sequence(&mut seq)
+        .returns_error("failed calculating total supply".into());
+
+    let mut batch = ethcontract::batch::CallBatch::new(contract.transport());
+
+    let name = instance.name().batch_call(&mut batch);
+    let symbol = instance.symbol().batch_call(&mut batch);
+    let decimals = instance.decimals().batch_call(&mut batch);
+    let total_supply = instance.total_supply().batch_call(&mut batch);
+
+    batch.execute_all(4).await;
+
+    assert_eq!(name.await?, "WrappedEther");
+    assert_eq!(symbol.await?, "WETH");
+    assert_eq!(decimals.await?, 18);
+    assert!(total_supply
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("failed calculating total supply"));
+
+    Ok(())
+}

--- a/ethcontract-mock/src/test/eth_block_number.rs
+++ b/ethcontract-mock/src/test/eth_block_number.rs
@@ -14,7 +14,7 @@ async fn block_number_initially_zero() -> Result {
 async fn block_number_advanced_after_tx() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(web3.eth().block_number().await?, 0.into());
 
@@ -33,7 +33,7 @@ async fn block_number_advanced_and_confirmed_after_tx() -> Result {
     let (_, web3, contract, instance) = setup();
 
     contract
-        .expect(IERC20::signatures().transfer())
+        .expect(ERC20::signatures().transfer())
         .confirmations(5);
 
     assert_eq!(web3.eth().block_number().await?, 0.into());
@@ -52,7 +52,7 @@ async fn block_number_advanced_and_confirmed_after_tx() -> Result {
 async fn block_number_is_not_advanced_after_call_or_gas_estimation() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(web3.eth().block_number().await?, 0.into());
 

--- a/ethcontract-mock/src/test/eth_estimate_gas.rs
+++ b/ethcontract-mock/src/test/eth_estimate_gas.rs
@@ -5,7 +5,7 @@ use ethcontract::web3::types::CallRequest;
 async fn estimate_gas_returns_one() -> Result {
     let (_, _, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let gas = instance
         .transfer(address_for("Alice"), 100.into())
@@ -22,7 +22,7 @@ async fn estimate_gas_returns_one() -> Result {
 async fn estimate_gas_is_supported_for_edge_block() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     instance
         .transfer(address_for("Bob"), 100.into())
@@ -77,7 +77,7 @@ async fn estimate_gas_is_supported_for_edge_block() -> Result {
 async fn estimate_gas_is_not_supported_for_custom_block() {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let request = {
         let tx = instance
@@ -107,7 +107,7 @@ async fn estimate_gas_is_not_supported_for_custom_block() {
 async fn estimate_gas_is_not_supported_for_earliest_block() {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let request = {
         let tx = instance

--- a/ethcontract-mock/src/test/eth_get_transaction_receipt.rs
+++ b/ethcontract-mock/src/test/eth_get_transaction_receipt.rs
@@ -5,7 +5,7 @@ use ethcontract::transaction::ResolveCondition;
 async fn transaction_receipt_is_returned() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let hash = instance
         .transfer(address_for("Bob"), 100.into())

--- a/ethcontract-mock/src/test/eth_transaction_count.rs
+++ b/ethcontract-mock/src/test/eth_transaction_count.rs
@@ -20,7 +20,7 @@ async fn transaction_count_initially_zero() -> Result {
 async fn transaction_count_advanced_after_tx() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(
         web3.eth()
@@ -48,7 +48,7 @@ async fn transaction_count_advanced_after_tx() -> Result {
 async fn transaction_count_is_not_advanced_after_call_or_gas_estimation() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(
         web3.eth()
@@ -89,7 +89,7 @@ async fn transaction_count_is_not_advanced_after_call_or_gas_estimation() -> Res
 async fn transaction_count_is_supported_for_edge_block() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     instance
         .transfer(address_for("Bob"), 100.into())

--- a/ethcontract-mock/src/test/mod.rs
+++ b/ethcontract-mock/src/test/mod.rs
@@ -68,6 +68,7 @@ use ethcontract::dyns::DynWeb3;
 use ethcontract::prelude::*;
 use predicates::prelude::*;
 
+mod batch;
 mod eth_block_number;
 mod eth_chain_id;
 mod eth_estimate_gas;
@@ -78,13 +79,13 @@ mod eth_transaction_count;
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
-ethcontract::contract!("examples/truffle/build/contracts/IERC20.json");
+ethcontract::contract!("examples/truffle/build/contracts/ERC20.json");
 
-fn setup() -> (Mock, DynWeb3, Contract, IERC20) {
+fn setup() -> (Mock, DynWeb3, Contract, ERC20) {
     let mock = Mock::new(1234);
     let web3 = mock.web3();
-    let contract = mock.deploy(IERC20::raw_contract().abi.clone());
-    let mut instance = IERC20::at(&web3, contract.address);
+    let contract = mock.deploy(ERC20::raw_contract().abi.clone());
+    let mut instance = ERC20::at(&web3, contract.address);
     instance.defaults_mut().from = Some(account_for("Alice"));
 
     (mock, web3, contract, instance)
@@ -93,21 +94,21 @@ fn setup() -> (Mock, DynWeb3, Contract, IERC20) {
 #[tokio::test]
 async fn general_test() {
     let mock = crate::Mock::new(1234);
-    let contract = mock.deploy(IERC20::raw_contract().abi.clone());
+    let contract = mock.deploy(ERC20::raw_contract().abi.clone());
 
     let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     let mut sequence = mockall::Sequence::new();
 
     contract
-        .expect(IERC20::signatures().balance_of())
+        .expect(ERC20::signatures().balance_of())
         .once()
         .predicate((predicate::eq(address_for("Bob")),))
         .returns(U256::from(0))
         .in_sequence(&mut sequence);
 
     contract
-        .expect(IERC20::signatures().transfer())
+        .expect(ERC20::signatures().transfer())
         .once()
         .predicate_fn_ctx(|ctx, _| !ctx.is_view_call)
         .returns_fn_ctx({
@@ -129,18 +130,18 @@ async fn general_test() {
         .in_sequence(&mut sequence);
 
     contract
-        .expect(IERC20::signatures().balance_of())
+        .expect(ERC20::signatures().balance_of())
         .once()
         .predicate((predicate::eq(address_for("Bob")),))
         .returns(U256::from(100))
         .in_sequence(&mut sequence);
 
     contract
-        .expect(IERC20::signatures().balance_of())
+        .expect(ERC20::signatures().balance_of())
         .predicate((predicate::eq(address_for("Alice")),))
         .returns(U256::from(100000));
 
-    let actual_contract = IERC20::at(&mock.web3(), contract.address);
+    let actual_contract = ERC20::at(&mock.web3(), contract.address);
 
     let balance = actual_contract
         .balance_of(address_for("Bob"))


### PR DESCRIPTION
This is required to use mock transport in GPv2 code.

### Test Plan
Added test for batches in mock transport. The rest is covered by existing tests.
