### PR TITLE
Implement `DynBatchTransport`

### DIFF
--- a/ethcontract-mock/src/lib.rs
+++ b/ethcontract-mock/src/lib.rs
@@ -221,7 +221,7 @@ use crate::predicate::TuplePredicate;
 use crate::range::TimesRange;
 use ethcontract::common::hash::H32;
 use ethcontract::common::Abi;
-use ethcontract::dyns::{DynInstance, DynTransport, DynWeb3};
+use ethcontract::dyns::{DynBatchInstance, DynBatchTransport, DynBatchWeb3};
 use ethcontract::tokens::Tokenize;
 use ethcontract::{Address, U256};
 use std::marker::PhantomData;
@@ -268,14 +268,14 @@ impl Mock {
 
     /// Creates a `Web3` object that can be used to interact with
     /// the mocked chain.
-    pub fn web3(&self) -> DynWeb3 {
-        DynWeb3::new(self.transport())
+    pub fn web3(&self) -> DynBatchWeb3 {
+        DynBatchWeb3::new(self.transport())
     }
 
     /// Creates a `Transport` object that can be used to interact with
     /// the mocked chain.
-    pub fn transport(&self) -> DynTransport {
-        DynTransport::new(self.transport.clone())
+    pub fn transport(&self) -> DynBatchTransport {
+        DynBatchTransport::new(self.transport.clone())
     }
 
     /// Deploys a new mocked contract and returns an object that allows
@@ -332,26 +332,26 @@ pub struct Contract {
 impl Contract {
     /// Creates a `Web3` object that can be used to interact with
     /// the mocked chain on which this contract is deployed.
-    pub fn web3(&self) -> DynWeb3 {
-        DynWeb3::new(self.transport())
+    pub fn web3(&self) -> DynBatchWeb3 {
+        DynBatchWeb3::new(self.transport())
     }
 
     /// Creates a `Transport` object that can be used to interact with
     /// the mocked chain.
-    pub fn transport(&self) -> DynTransport {
-        DynTransport::new(self.transport.clone())
+    pub fn transport(&self) -> DynBatchTransport {
+        DynBatchTransport::new(self.transport.clone())
     }
 
     /// Creates a contract `Instance` that can be used to interact with
     /// this contract.
-    pub fn instance(&self) -> DynInstance {
-        DynInstance::at(self.web3(), self.abi.clone(), self.address)
+    pub fn instance(&self) -> DynBatchInstance {
+        DynBatchInstance::at(self.web3(), self.abi.clone(), self.address)
     }
 
     /// Consumes this object and transforms it into a contract `Instance`
     /// that can be used to interact with this contract.
-    pub fn into_instance(self) -> DynInstance {
-        DynInstance::at(self.web3(), self.abi, self.address)
+    pub fn into_instance(self) -> DynBatchInstance {
+        DynBatchInstance::at(self.web3(), self.abi, self.address)
     }
 
     /// Returns a reference to the contract's ABI.

--- a/ethcontract-mock/src/test/batch.rs
+++ b/ethcontract-mock/src/test/batch.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+#[tokio::test]
+async fn batch_ok() -> Result {
+    let (_, _, contract, instance) = setup();
+
+    let mut seq = mockall::Sequence::new();
+
+    contract
+        .expect(ERC20::signatures().name())
+        .once()
+        .in_sequence(&mut seq)
+        .returns("WrappedEther".into());
+    contract
+        .expect(ERC20::signatures().symbol())
+        .once()
+        .in_sequence(&mut seq)
+        .returns("WETH".into());
+    contract
+        .expect(ERC20::signatures().decimals())
+        .once()
+        .returns(18)
+        .in_sequence(&mut seq);
+    contract
+        .expect(ERC20::signatures().total_supply())
+        .once()
+        .in_sequence(&mut seq)
+        .returns_error("failed calculating total supply".into());
+
+    let mut batch = ethcontract::batch::CallBatch::new(contract.transport());
+
+    let name = instance.name().batch_call(&mut batch);
+    let symbol = instance.symbol().batch_call(&mut batch);
+    let decimals = instance.decimals().batch_call(&mut batch);
+    let total_supply = instance.total_supply().batch_call(&mut batch);
+
+    batch.execute_all(4).await;
+
+    assert_eq!(name.await?, "WrappedEther");
+    assert_eq!(symbol.await?, "WETH");
+    assert_eq!(decimals.await?, 18);
+    assert!(total_supply
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("failed calculating total supply"));
+
+    Ok(())
+}

--- a/ethcontract-mock/src/test/eth_block_number.rs
+++ b/ethcontract-mock/src/test/eth_block_number.rs
@@ -14,7 +14,7 @@ async fn block_number_initially_zero() -> Result {
 async fn block_number_advanced_after_tx() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(web3.eth().block_number().await?, 0.into());
 
@@ -33,7 +33,7 @@ async fn block_number_advanced_and_confirmed_after_tx() -> Result {
     let (_, web3, contract, instance) = setup();
 
     contract
-        .expect(IERC20::signatures().transfer())
+        .expect(ERC20::signatures().transfer())
         .confirmations(5);
 
     assert_eq!(web3.eth().block_number().await?, 0.into());
@@ -52,7 +52,7 @@ async fn block_number_advanced_and_confirmed_after_tx() -> Result {
 async fn block_number_is_not_advanced_after_call_or_gas_estimation() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(web3.eth().block_number().await?, 0.into());
 

--- a/ethcontract-mock/src/test/eth_estimate_gas.rs
+++ b/ethcontract-mock/src/test/eth_estimate_gas.rs
@@ -5,7 +5,7 @@ use ethcontract::web3::types::CallRequest;
 async fn estimate_gas_returns_one() -> Result {
     let (_, _, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let gas = instance
         .transfer(address_for("Alice"), 100.into())
@@ -22,7 +22,7 @@ async fn estimate_gas_returns_one() -> Result {
 async fn estimate_gas_is_supported_for_edge_block() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     instance
         .transfer(address_for("Bob"), 100.into())
@@ -77,7 +77,7 @@ async fn estimate_gas_is_supported_for_edge_block() -> Result {
 async fn estimate_gas_is_not_supported_for_custom_block() {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let request = {
         let tx = instance
@@ -107,7 +107,7 @@ async fn estimate_gas_is_not_supported_for_custom_block() {
 async fn estimate_gas_is_not_supported_for_earliest_block() {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let request = {
         let tx = instance

--- a/ethcontract-mock/src/test/eth_get_transaction_receipt.rs
+++ b/ethcontract-mock/src/test/eth_get_transaction_receipt.rs
@@ -5,7 +5,7 @@ use ethcontract::transaction::ResolveCondition;
 async fn transaction_receipt_is_returned() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     let hash = instance
         .transfer(address_for("Bob"), 100.into())

--- a/ethcontract-mock/src/test/eth_transaction_count.rs
+++ b/ethcontract-mock/src/test/eth_transaction_count.rs
@@ -20,7 +20,7 @@ async fn transaction_count_initially_zero() -> Result {
 async fn transaction_count_advanced_after_tx() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(
         web3.eth()
@@ -48,7 +48,7 @@ async fn transaction_count_advanced_after_tx() -> Result {
 async fn transaction_count_is_not_advanced_after_call_or_gas_estimation() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     assert_eq!(
         web3.eth()
@@ -89,7 +89,7 @@ async fn transaction_count_is_not_advanced_after_call_or_gas_estimation() -> Res
 async fn transaction_count_is_supported_for_edge_block() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    contract.expect(IERC20::signatures().transfer());
+    contract.expect(ERC20::signatures().transfer());
 
     instance
         .transfer(address_for("Bob"), 100.into())

--- a/ethcontract/src/lib.rs
+++ b/ethcontract/src/lib.rs
@@ -138,7 +138,7 @@ pub mod dyns {
     use crate::contract::{
         AllEventsBuilder, DeployBuilder, EventBuilder, Instance, MethodBuilder, ViewMethodBuilder,
     };
-    pub use crate::transport::{DynTransport, DynBatchTransport};
+    pub use crate::transport::{DynBatchTransport, DynTransport};
     use web3::api::Web3;
 
     /// Type alias for a `Web3` with an underlying `DynTransport`.

--- a/ethcontract/src/lib.rs
+++ b/ethcontract/src/lib.rs
@@ -138,7 +138,7 @@ pub mod dyns {
     use crate::contract::{
         AllEventsBuilder, DeployBuilder, EventBuilder, Instance, MethodBuilder, ViewMethodBuilder,
     };
-    pub use crate::transport::DynTransport;
+    pub use crate::transport::{DynTransport, DynBatchTransport};
     use web3::api::Web3;
 
     /// Type alias for a `Web3` with an underlying `DynTransport`.
@@ -161,6 +161,27 @@ pub mod dyns {
 
     /// Type alias for a `LogStream` with an underlying `DynTransport`.
     pub type DynAllEventsBuilder<E> = AllEventsBuilder<DynTransport, E>;
+
+    /// Type alias for a `Web3` with an underlying `DynBatchTransport`.
+    pub type DynBatchWeb3 = Web3<DynBatchTransport>;
+
+    /// Type alias for an `Instance` with an underlying `DynBatchTransport`.
+    pub type DynBatchInstance = Instance<DynBatchTransport>;
+
+    /// Type alias for a `DeployBuilder` with an underlying `DynBatchTransport`.
+    pub type DynBatchDeployBuilder<D> = DeployBuilder<DynBatchTransport, D>;
+
+    /// Type alias for a `MethodBuilder` with an underlying `DynBatchTransport`.
+    pub type DynBatchMethodBuilder<R> = MethodBuilder<DynBatchTransport, R>;
+
+    /// Type alias for a `ViewMethodBuilder` with an underlying `DynBatchTransport`.
+    pub type DynBatchViewMethodBuilder<R> = ViewMethodBuilder<DynBatchTransport, R>;
+
+    /// Type alias for a `EventBuilder` with an underlying `DynBatchTransport`.
+    pub type DynBatchEventBuilder<E> = EventBuilder<DynBatchTransport, E>;
+
+    /// Type alias for a `LogStream` with an underlying `DynBatchTransport`.
+    pub type DynBatchAllEventsBuilder<E> = AllEventsBuilder<DynBatchTransport, E>;
 }
 
 #[doc(hidden)]

--- a/ethcontract/src/transport.rs
+++ b/ethcontract/src/transport.rs
@@ -197,7 +197,7 @@ impl BatchTransport for DynBatchTransport {
 impl From<DynBatchTransport> for DynTransport {
     fn from(t: DynBatchTransport) -> Self {
         DynTransport {
-            inner: t.inner.into_transport()
+            inner: t.inner.into_transport(),
         }
     }
 }


### PR DESCRIPTION
This is required to use mock transport in GPv2 code.

### Test Plan
Added test for batches in mock transport. The rest is covered by existing tests.
