### PR TITLE
Release 0.16.0

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,8 +16,8 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
-ethcontract-common = { version = "0.15.1", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.15.1", path = "../ethcontract-generate" }
+ethcontract-common = { version = "0.15.2", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.15.2", path = "../ethcontract-generate" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.12"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ Code generation for type-safe bindings to Ethereum smart contracts.
 [dependencies]
 anyhow = "1.0"
 curl = "0.4"
-ethcontract-common = { version = "0.15.1", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.15.2", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-mock"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ Tools for mocking ethereum contracts.
 """
 
 [dependencies]
-ethcontract = { version = "0.15.1", path = "../ethcontract" }
+ethcontract = { version = "0.15.2", path = "../ethcontract" }
 hex = "0.4"
 mockall = "0.10"
 rlp = "0.5"
@@ -20,4 +20,4 @@ predicates = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.6", features = ["macros"] }
-ethcontract-derive = { version = "0.15.1", path = "../ethcontract-derive" }
+ethcontract-derive = { version = "0.15.2", path = "../ethcontract-derive" }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -31,8 +31,8 @@ ipc-tokio = ["web3/ipc-tokio"]
 
 [dependencies]
 arrayvec = "0.7"
-ethcontract-common = { version = "0.15.1", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.15.1", path = "../ethcontract-derive", optional = true}
+ethcontract-common = { version = "0.15.2", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.15.2", path = "../ethcontract-derive", optional = true}
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"


### PR DESCRIPTION
- Support `net_version` call (#619)
- Add ability to downcast `DynTransport` (#608)


### Test Plan

CI
