### PR TITLE
Fix handling of functions that return multiple values

### DIFF
--- a/ethcontract-mock/src/details/default.rs
+++ b/ethcontract-mock/src/details/default.rs
@@ -15,11 +15,6 @@ pub fn default(ty: &ParamType) -> Token {
         ParamType::Array(_) => Token::Array(Vec::new()),
         ParamType::FixedBytes(n) => Token::FixedBytes(vec![0; *n]),
         ParamType::FixedArray(ty, n) => Token::FixedArray(vec![default(ty); *n]),
-        ParamType::Tuple(tys) => default_tuple(tys.iter()),
+        ParamType::Tuple(tys) => Token::Tuple(tys.iter().map(default).collect()),
     }
-}
-
-/// Builds a default value for the given solidity tuple type.
-pub fn default_tuple<'a>(tys: impl Iterator<Item = &'a ParamType>) -> Token {
-    Token::Tuple(tys.map(default).collect())
 }

--- a/ethcontract-mock/src/test/mod.rs
+++ b/ethcontract-mock/src/test/mod.rs
@@ -77,6 +77,7 @@ mod eth_get_transaction_receipt;
 mod eth_send_transaction;
 mod eth_transaction_count;
 mod net_version;
+mod returns;
 
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 

--- a/ethcontract-mock/src/test/returns.rs
+++ b/ethcontract-mock/src/test/returns.rs
@@ -1,0 +1,165 @@
+use super::*;
+
+ethcontract::contract!("examples/truffle/build/contracts/AbiTypes.json");
+
+#[tokio::test]
+async fn returns_default() -> Result {
+    let contract = Mock::new(1234).deploy(AbiTypes::raw_contract().abi.clone());
+
+    contract.expect(AbiTypes::signatures().get_void());
+    contract.expect(AbiTypes::signatures().get_u8());
+    contract.expect(AbiTypes::signatures().abiv_2_struct());
+    contract.expect(AbiTypes::signatures().abiv_2_array_of_struct());
+    contract.expect(AbiTypes::signatures().multiple_results());
+    contract.expect(AbiTypes::signatures().multiple_results_struct());
+
+    let instance = AbiTypes::at(&contract.web3(), contract.address);
+
+    let _: () = instance.get_void().call().await?;
+    assert_eq!(instance.get_u8().call().await?, 0);
+    assert_eq!(instance.abiv_2_struct((1, 2)).call().await?, (0, 0));
+    assert_eq!(
+        instance
+            .abiv_2_array_of_struct(vec![(1, 2), (3, 4)])
+            .call()
+            .await?,
+        vec![]
+    );
+    assert_eq!(instance.multiple_results().call().await?, (0, 0, 0));
+    assert_eq!(
+        instance.multiple_results_struct().call().await?,
+        ((0, 0), (0, 0))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn returns_const() -> Result {
+    let contract = Mock::new(1234).deploy(AbiTypes::raw_contract().abi.clone());
+
+    contract
+        .expect(AbiTypes::signatures().get_void())
+        .returns(());
+    contract.expect(AbiTypes::signatures().get_u8()).returns(42);
+    contract
+        .expect(AbiTypes::signatures().abiv_2_struct())
+        .returns((1, 2));
+    contract
+        .expect(AbiTypes::signatures().abiv_2_array_of_struct())
+        .returns(vec![(1, 2), (3, 4)]);
+    contract
+        .expect(AbiTypes::signatures().multiple_results())
+        .returns((1, 2, 3));
+    contract
+        .expect(AbiTypes::signatures().multiple_results_struct())
+        .returns(((1, 2), (3, 4)));
+
+    let instance = AbiTypes::at(&contract.web3(), contract.address);
+
+    let _: () = instance.get_void().call().await?;
+    assert_eq!(instance.get_u8().call().await?, 42);
+    assert_eq!(instance.abiv_2_struct((1, 2)).call().await?, (1, 2));
+    assert_eq!(
+        instance
+            .abiv_2_array_of_struct(vec![(1, 2), (3, 4)])
+            .call()
+            .await?,
+        vec![(1, 2), (3, 4)]
+    );
+    assert_eq!(instance.multiple_results().call().await?, (1, 2, 3));
+    assert_eq!(
+        instance.multiple_results_struct().call().await?,
+        ((1, 2), (3, 4))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn returns_fn() -> Result {
+    let contract = Mock::new(1234).deploy(AbiTypes::raw_contract().abi.clone());
+
+    contract
+        .expect(AbiTypes::signatures().get_void())
+        .returns_fn(|_| Ok(()));
+    contract
+        .expect(AbiTypes::signatures().get_u8())
+        .returns_fn(|_| Ok(42));
+    contract
+        .expect(AbiTypes::signatures().abiv_2_struct())
+        .returns_fn(|(x,)| Ok(x));
+    contract
+        .expect(AbiTypes::signatures().abiv_2_array_of_struct())
+        .returns_fn(|(x,)| Ok(x));
+    contract
+        .expect(AbiTypes::signatures().multiple_results())
+        .returns_fn(|_| Ok((1, 2, 3)));
+    contract
+        .expect(AbiTypes::signatures().multiple_results_struct())
+        .returns_fn(|_| Ok(((1, 2), (3, 4))));
+
+    let instance = AbiTypes::at(&contract.web3(), contract.address);
+
+    let _: () = instance.get_void().call().await?;
+    assert_eq!(instance.get_u8().call().await?, 42);
+    assert_eq!(instance.abiv_2_struct((1, 2)).call().await?, (1, 2));
+    assert_eq!(
+        instance
+            .abiv_2_array_of_struct(vec![(1, 2), (3, 4)])
+            .call()
+            .await?,
+        vec![(1, 2), (3, 4)]
+    );
+    assert_eq!(instance.multiple_results().call().await?, (1, 2, 3));
+    assert_eq!(
+        instance.multiple_results_struct().call().await?,
+        ((1, 2), (3, 4))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn returns_fn_ctx() -> Result {
+    let contract = Mock::new(1234).deploy(AbiTypes::raw_contract().abi.clone());
+
+    contract
+        .expect(AbiTypes::signatures().get_void())
+        .returns_fn_ctx(|_, _| Ok(()));
+    contract
+        .expect(AbiTypes::signatures().get_u8())
+        .returns_fn_ctx(|_, _| Ok(42));
+    contract
+        .expect(AbiTypes::signatures().abiv_2_struct())
+        .returns_fn_ctx(|_, (x,)| Ok(x));
+    contract
+        .expect(AbiTypes::signatures().abiv_2_array_of_struct())
+        .returns_fn_ctx(|_, (x,)| Ok(x));
+    contract
+        .expect(AbiTypes::signatures().multiple_results())
+        .returns_fn_ctx(|_, _| Ok((1, 2, 3)));
+    contract
+        .expect(AbiTypes::signatures().multiple_results_struct())
+        .returns_fn_ctx(|_, _| Ok(((1, 2), (3, 4))));
+
+    let instance = AbiTypes::at(&contract.web3(), contract.address);
+
+    let _: () = instance.get_void().call().await?;
+    assert_eq!(instance.get_u8().call().await?, 42);
+    assert_eq!(instance.abiv_2_struct((1, 2)).call().await?, (1, 2));
+    assert_eq!(
+        instance
+            .abiv_2_array_of_struct(vec![(1, 2), (3, 4)])
+            .call()
+            .await?,
+        vec![(1, 2), (3, 4)]
+    );
+    assert_eq!(instance.multiple_results().call().await?, (1, 2, 3));
+    assert_eq!(
+        instance.multiple_results_struct().call().await?,
+        ((1, 2), (3, 4))
+    );
+
+    Ok(())
+}

--- a/examples/truffle/contracts/AbiTypes.sol
+++ b/examples/truffle/contracts/AbiTypes.sol
@@ -137,5 +137,10 @@ contract AbiTypes {
   function roundtripFixedU8Array(uint8[3] calldata a) public view returns (uint8[3] calldata) {
     return a;
   }
-
+  function multipleResults() public view returns (uint8, uint8, uint8) {
+    return (1, 2, 3);
+  }
+  function multipleResultsStruct() public view returns (S memory, S memory) {
+    return (S(0, 1), S(2, 3));
+  }
 }


### PR DESCRIPTION
When ethcontract determines appropriate rust type for function output, it has a special case for functions that return a single element. Normally, function return type would always be a tuple. With a single return value, the tuple is unwrapped to make code more ergonomic:

- for `function x()` output type is `()`,
- for `function x() returns (T)` output type is `T` (not `(T,)`),
- for `function x() returns (A, B, ...)` output type is `(A, B, ...)`.

We need to account for this conversion and wrap output of any function that returns a single value into an additional tuple.

### Test Plan
New unit tests
