### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/ethcontract-generate/src/source.rs
+++ b/ethcontract-generate/src/source.rs
@@ -99,8 +99,9 @@ impl Source {
     /// directory for resolving relative paths. See [`parse`] for more details
     /// on supported source strings.
     pub fn with_root(root: impl AsRef<Path>, source: &str) -> Result<Self> {
+        let root = root.as_ref();
         let base = Url::from_directory_path(root)
-            .map_err(|_| anyhow!("root path '{}' is not absolute"))?;
+            .map_err(|_| anyhow!("root path '{}' is not absolute", root.display()))?;
         let url = base.join(source.as_ref())?;
 
         match url.scheme() {


### PR DESCRIPTION
Without this, the error message would literally be "root path '{}' is not absolute" with curly braces in it instead of the root path.

### Test Plan
`cargo check --manifest-path ethcontract-generate/Cargo.toml`