### PR TITLE
Adjust `must_use` Lints

### DIFF
--- a/ethcontract-common/src/artifact/hardhat.rs
+++ b/ethcontract-common/src/artifact/hardhat.rs
@@ -52,6 +52,7 @@ use std::path::Path;
 /// have to filter such networks. See [#545] for more info.
 ///
 /// [#545]: https://github.com/gnosis/ethcontract-rs/issues/545.
+#[must_use = "hardhat loaders do nothing unless you load them"]
 pub struct HardHatLoader {
     /// Override for artifact's origin. If `None`, origin
     /// will be derived automatically.
@@ -124,7 +125,6 @@ impl HardHatLoader {
     /// Sets new override for artifact's origin. See [`origin`] for more info.
     ///
     /// [`origin`]: #structfield.origin
-    #[must_use]
     pub fn origin(mut self, origin: impl Into<String>) -> Self {
         self.origin = Some(origin.into());
         self
@@ -133,7 +133,6 @@ impl HardHatLoader {
     /// Adds chain id to the list of [`allowed networks`].
     ///
     /// [`allowed networks`]: #structfield.networks_allow_list
-    #[must_use]
     pub fn allow_network_by_chain_id(mut self, network: impl Into<String>) -> Self {
         self.networks_allow_list
             .push(NetworkEntry::ByChainId(network.into()));
@@ -143,7 +142,6 @@ impl HardHatLoader {
     /// Adds network name to the list of [`allowed networks`].
     ///
     /// [`allowed networks`]: #structfield.networks_allow_list
-    #[must_use]
     pub fn allow_network_by_name(mut self, network: impl Into<String>) -> Self {
         self.networks_allow_list
             .push(NetworkEntry::ByName(network.into()));
@@ -153,7 +151,6 @@ impl HardHatLoader {
     /// Adds chain id to the list of [`denied networks`].
     ///
     /// [`denied networks`]: #structfield.networks_deny_list
-    #[must_use]
     pub fn deny_network_by_chain_id(mut self, network: impl Into<String>) -> Self {
         self.networks_deny_list
             .push(NetworkEntry::ByChainId(network.into()));
@@ -163,7 +160,6 @@ impl HardHatLoader {
     /// Adds network name to the list of [`denied networks`].
     ///
     /// [`denied networks`]: #structfield.networks_deny_list
-    #[must_use]
     pub fn deny_network_by_name(mut self, network: impl Into<String>) -> Self {
         self.networks_deny_list
             .push(NetworkEntry::ByName(network.into()));
@@ -173,7 +169,6 @@ impl HardHatLoader {
     /// Adds contract name to the list of [`allowed contracts`].
     ///
     /// [`allowed contracts`]: #structfield.contracts_allow_list
-    #[must_use]
     pub fn allow_contract(mut self, contract: impl Into<String>) -> Self {
         self.contracts_allow_list.push(contract.into());
         self
@@ -182,7 +177,6 @@ impl HardHatLoader {
     /// Adds contract name to the list of [`denied contracts`].
     ///
     /// [`denied contracts`]: #structfield.contracts_deny_list
-    #[must_use]
     pub fn deny_contract(mut self, contract: impl Into<String>) -> Self {
         self.contracts_deny_list.push(contract.into());
         self

--- a/ethcontract-common/src/artifact/truffle.rs
+++ b/ethcontract-common/src/artifact/truffle.rs
@@ -19,6 +19,7 @@ use std::io::{BufReader, Read};
 use std::path::Path;
 
 /// Loads truffle artifacts.
+#[must_use = "truffle loaders do nothing unless you load them"]
 pub struct TruffleLoader {
     /// Override for artifact's origin.
     ///
@@ -51,7 +52,6 @@ impl TruffleLoader {
     /// Sets new override for artifact's origin. See [`origin`] for more info.
     ///
     /// [`origin`]: #structfield.origin
-    #[must_use]
     pub fn origin(mut self, origin: impl Into<String>) -> Self {
         self.origin = Some(origin.into());
         self
@@ -60,7 +60,6 @@ impl TruffleLoader {
     /// Sets new override for artifact's name. See [`name`] for more info.
     ///
     /// [`name`]: #structfield.name
-    #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self

--- a/ethcontract-generate/src/lib.rs
+++ b/ethcontract-generate/src/lib.rs
@@ -157,7 +157,7 @@ impl ContractBuilder {
     /// copy of `rustfmt`.
     ///
     /// Note that in case `rustfmt` does not exist or produces an error, the
-    /// unformatted code will be used.
+    /// un-formatted code will be used.
     pub fn rustfmt(mut self, rustfmt: bool) -> Self {
         self.rustfmt = rustfmt;
         self
@@ -212,7 +212,7 @@ impl ContractBindings {
     /// copy of `rustfmt`.
     ///
     /// Note that in case `rustfmt` does not exist or produces an error, the
-    /// unformatted code will be used.
+    /// un-formatted code will be used.
     #[must_use = "specifying rustfmt does nothing unless you write bindings"]
     pub fn rustfmt(mut self, rustfmt: bool) -> Self {
         self.rustfmt = rustfmt;

--- a/ethcontract-generate/src/lib.rs
+++ b/ethcontract-generate/src/lib.rs
@@ -41,6 +41,7 @@ use std::path::Path;
 
 /// Builder for generating contract code. Note that no code is generated until
 /// the builder is finalized with `generate` or `output`.
+#[must_use = "contract builders do nothing unless you generate bindings"]
 pub struct ContractBuilder {
     /// The runtime crate name to use.
     pub runtime_crate_name: String,
@@ -85,7 +86,6 @@ impl ContractBuilder {
 
     /// Sets the crate name for the runtime crate. This setting is usually only
     /// needed if the crate was renamed in the Cargo manifest.
-    #[must_use]
     pub fn runtime_crate_name(mut self, name: impl Into<String>) -> Self {
         self.runtime_crate_name = name.into();
         self
@@ -93,14 +93,12 @@ impl ContractBuilder {
 
     /// Sets an optional visibility modifier for the generated module and
     /// contract re-export.
-    #[must_use]
     pub fn visibility_modifier(mut self, vis: impl Into<String>) -> Self {
         self.visibility_modifier = Some(vis.into());
         self
     }
 
     /// Sets the optional contract module name override.
-    #[must_use]
     pub fn contract_mod_override(mut self, name: impl Into<String>) -> Self {
         self.contract_mod_override = Some(name.into());
         self
@@ -109,7 +107,6 @@ impl ContractBuilder {
     /// Sets the optional contract name override. This setting is needed when
     /// using an artifact JSON source that does not provide a contract name such
     /// as Etherscan.
-    #[must_use]
     pub fn contract_name_override(mut self, name: impl Into<String>) -> Self {
         self.contract_name_override = Some(name.into());
         self
@@ -122,7 +119,6 @@ impl ContractBuilder {
     /// This is useful for integration test scenarios where the address of a
     /// contract on the test node is deterministic, but the contract address
     /// is not in the artifact.
-    #[must_use]
     pub fn add_network(mut self, chain_id: impl Into<String>, network: Network) -> Self {
         self.networks.insert(chain_id.into(), network);
         self
@@ -135,7 +131,6 @@ impl ContractBuilder {
     ///
     /// This method panics if the specified address string is invalid. See
     /// [`parse_address`] for more information on the address string format.
-    #[must_use]
     pub fn add_network_str(self, chain_id: impl Into<String>, address: &str) -> Self {
         self.add_network(
             chain_id,
@@ -149,7 +144,6 @@ impl ContractBuilder {
     /// Adds a solidity method alias to specify what the method name
     /// will be in Rust. For solidity methods without an alias, the snake cased
     /// method name will be used.
-    #[must_use]
     pub fn add_method_alias(
         mut self,
         signature: impl Into<String>,
@@ -163,8 +157,7 @@ impl ContractBuilder {
     /// copy of `rustfmt`.
     ///
     /// Note that in case `rustfmt` does not exist or produces an error, the
-    /// un-formatted code will be used.
-    #[must_use]
+    /// unformatted code will be used.
     pub fn rustfmt(mut self, rustfmt: bool) -> Self {
         self.rustfmt = rustfmt;
         self
@@ -183,7 +176,6 @@ impl ContractBuilder {
     ///     .add_event_derive("serde::Serialize")
     ///     .add_event_derive("serde::Deserialize");
     /// ```
-    #[must_use]
     pub fn add_event_derive(mut self, derive: impl Into<String>) -> Self {
         self.event_derives.push(derive.into());
         self
@@ -220,8 +212,8 @@ impl ContractBindings {
     /// copy of `rustfmt`.
     ///
     /// Note that in case `rustfmt` does not exist or produces an error, the
-    /// un-formatted code will be used.
-    #[must_use]
+    /// unformatted code will be used.
+    #[must_use = "specifying rustfmt does nothing unless you write bindings"]
     pub fn rustfmt(mut self, rustfmt: bool) -> Self {
         self.rustfmt = rustfmt;
         self

--- a/ethcontract-mock/src/lib.rs
+++ b/ethcontract-mock/src/lib.rs
@@ -482,6 +482,12 @@ pub struct Expectation<P: Tokenize + Send + 'static, R: Tokenize + Send + 'stati
     _ph: PhantomData<(P, R)>,
 }
 
+// Allow not requiring `must_use` as `Expectation`s have side effects, but
+// return `Self` as a convenience for chaining operations. Note that this lint
+// is on nighlty only, so we also need to allow `unknown_lints` here to silence
+// warnings on all Rust versions we build for.
+#[allow(unknown_lints)]
+#[allow(clippy::return_self_not_must_use)]
 impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, R> {
     /// Specifies how many times this expectation can be called.
     ///
@@ -590,7 +596,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// to the first expectation.
     ///
     /// [`once`]: Expectation::once
-    #[must_use]
     pub fn times(self, times: impl Into<TimesRange>) -> Self {
         self.transport.times::<P, R>(
             self.address,
@@ -607,7 +612,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// See [`times`] for more info.
     ///
     /// [`times`]: Expectation::times
-    #[must_use]
     pub fn never(self) -> Self {
         self.times(0)
     }
@@ -617,7 +621,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// See [`times`] for more info.
     ///
     /// [`times`]: Expectation::times
-    #[must_use]
     pub fn once(self) -> Self {
         self.times(1)
     }
@@ -638,7 +641,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// [mockall documentation]: https://docs.rs/mockall/#sequences
     /// [`times`]: Expectation::times
     /// [`once`]: Expectation::once
-    #[must_use]
     pub fn in_sequence(self, sequence: &mut mockall::Sequence) -> Self {
         self.transport.in_sequence::<P, R>(
             self.address,
@@ -653,7 +655,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// Sets number of blocks that should be mined on top of the transaction
     /// block. This method can be useful when there are custom transaction
     /// confirmation settings.
-    #[must_use]
     pub fn confirmations(self, confirmations: u64) -> Self {
         self.transport.confirmations::<P, R>(
             self.address,
@@ -714,7 +715,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// [call sequences]: Expectation::in_sequence
     /// [limiting number of expectation uses]: Expectation::times
     /// [`returns_fn`]: Expectation::returns_fn
-    #[must_use]
     pub fn predicate<T>(self, pred: T) -> Self
     where
         T: TuplePredicate<P> + Send + 'static,
@@ -737,7 +737,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// This method will overwrite any predicate that was set before.
     ///
     /// [`predicate`]: Expectation::predicate
-    #[must_use]
     pub fn predicate_fn(self, pred: impl Fn(&P) -> bool + Send + 'static) -> Self {
         self.transport.predicate_fn::<P, R>(
             self.address,
@@ -757,7 +756,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     ///
     /// [call context]: CallContext
     /// [`predicate`]: Expectation::predicate
-    #[must_use]
     pub fn predicate_fn_ctx(
         self,
         pred: impl Fn(&CallContext, &P) -> bool + Send + 'static,
@@ -780,7 +778,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// See also [`Contract::expect_call`].
     ///
     /// [`predicate`]: Expectation::predicate
-    #[must_use]
     pub fn allow_calls(self, allow_calls: bool) -> Self {
         self.transport.allow_calls::<P, R>(
             self.address,
@@ -800,7 +797,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// See also [`Contract::expect_transaction`].
     ///
     /// [`predicate`]: Expectation::predicate
-    #[must_use]
     pub fn allow_transactions(self, allow_transactions: bool) -> Self {
         self.transport.allow_transactions::<P, R>(
             self.address,
@@ -820,7 +816,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     ///
     /// This method will overwrite any return value or callback
     /// that was set before.
-    #[must_use]
     pub fn returns(self, returns: R) -> Self {
         self.transport.returns::<P, R>(
             self.address,
@@ -848,7 +843,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// See [`returns`] for more info.
     ///
     /// [`returns`]: Expectation::returns
-    #[must_use]
     pub fn returns_fn(self, returns: impl Fn(P) -> Result<R, String> + Send + 'static) -> Self {
         self.transport.returns_fn::<P, R>(
             self.address,
@@ -877,7 +871,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     ///
     /// [call context]: CallContext
     /// [`returns`]: Expectation::returns
-    #[must_use]
     pub fn returns_fn_ctx(
         self,
         returns: impl Fn(&CallContext, P) -> Result<R, String> + Send + 'static,
@@ -901,7 +894,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// See [`returns`] for more info.
     ///
     /// [`returns`]: Expectation::returns
-    #[must_use]
     pub fn returns_error(self, error: String) -> Self {
         self.transport.returns_error::<P, R>(
             self.address,
@@ -923,7 +915,6 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> Expectation<P, 
     /// it constructs default value according to solidity rules.
     ///
     /// [`returns`]: Expectation::returns
-    #[must_use]
     pub fn returns_default(self) -> Self {
         self.transport.returns_default::<P, R>(
             self.address,

--- a/ethcontract-mock/src/test/batch.rs
+++ b/ethcontract-mock/src/test/batch.rs
@@ -6,22 +6,22 @@ async fn batch_ok() -> Result {
 
     let mut seq = mockall::Sequence::new();
 
-    let _ = contract
+    contract
         .expect(ERC20::signatures().name())
         .once()
         .in_sequence(&mut seq)
         .returns("WrappedEther".into());
-    let _ = contract
+    contract
         .expect(ERC20::signatures().symbol())
         .once()
         .in_sequence(&mut seq)
         .returns("WETH".into());
-    let _ = contract
+    contract
         .expect(ERC20::signatures().decimals())
         .once()
         .returns(18)
         .in_sequence(&mut seq);
-    let _ = contract
+    contract
         .expect(ERC20::signatures().total_supply())
         .once()
         .in_sequence(&mut seq)

--- a/ethcontract-mock/src/test/eth_block_number.rs
+++ b/ethcontract-mock/src/test/eth_block_number.rs
@@ -32,7 +32,7 @@ async fn block_number_advanced_after_tx() -> Result {
 async fn block_number_advanced_and_confirmed_after_tx() -> Result {
     let (_, web3, contract, instance) = setup();
 
-    let _ = contract
+    contract
         .expect(ERC20::signatures().transfer())
         .confirmations(5);
 

--- a/ethcontract-mock/src/test/mod.rs
+++ b/ethcontract-mock/src/test/mod.rs
@@ -102,14 +102,14 @@ async fn general_test() {
 
     let mut sequence = mockall::Sequence::new();
 
-    let _ = contract
+    contract
         .expect(ERC20::signatures().balance_of())
         .once()
         .predicate((predicate::eq(address_for("Bob")),))
-        .returns(U256::from(0u64))
+        .returns(U256::from(0))
         .in_sequence(&mut sequence);
 
-    let _ = contract
+    contract
         .expect(ERC20::signatures().transfer())
         .once()
         .predicate_fn_ctx(|ctx, _| !ctx.is_view_call)
@@ -131,17 +131,17 @@ async fn general_test() {
         .confirmations(3)
         .in_sequence(&mut sequence);
 
-    let _ = contract
+    contract
         .expect(ERC20::signatures().balance_of())
         .once()
         .predicate((predicate::eq(address_for("Bob")),))
-        .returns(U256::from(100u64))
+        .returns(U256::from(100))
         .in_sequence(&mut sequence);
 
-    let _ = contract
+    contract
         .expect(ERC20::signatures().balance_of())
         .predicate((predicate::eq(address_for("Alice")),))
-        .returns(U256::from(100000u64));
+        .returns(U256::from(100000));
 
     let actual_contract = ERC20::at(&mock.web3(), contract.address);
 
@@ -154,7 +154,7 @@ async fn general_test() {
 
     assert!(!called.load(std::sync::atomic::Ordering::Relaxed));
     actual_contract
-        .transfer(address_for("Bob"), U256::from(100u64))
+        .transfer(address_for("Bob"), U256::from(100))
         .from(account_for("Alice"))
         .confirmations(3)
         .send()

--- a/ethcontract-mock/src/test/returns.rs
+++ b/ethcontract-mock/src/test/returns.rs
@@ -38,20 +38,20 @@ async fn returns_default() -> Result {
 async fn returns_const() -> Result {
     let contract = Mock::new(1234).deploy(AbiTypes::raw_contract().abi.clone());
 
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().get_void())
         .returns(());
-    let _ = contract.expect(AbiTypes::signatures().get_u8()).returns(42);
-    let _ = contract
+    contract.expect(AbiTypes::signatures().get_u8()).returns(42);
+    contract
         .expect(AbiTypes::signatures().abiv_2_struct())
         .returns((1, 2));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().abiv_2_array_of_struct())
         .returns(vec![(1, 2), (3, 4)]);
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().multiple_results())
         .returns((1, 2, 3));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().multiple_results_struct())
         .returns(((1, 2), (3, 4)));
 
@@ -80,22 +80,22 @@ async fn returns_const() -> Result {
 async fn returns_fn() -> Result {
     let contract = Mock::new(1234).deploy(AbiTypes::raw_contract().abi.clone());
 
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().get_void())
         .returns_fn(|_| Ok(()));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().get_u8())
         .returns_fn(|_| Ok(42));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().abiv_2_struct())
         .returns_fn(|(x,)| Ok(x));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().abiv_2_array_of_struct())
         .returns_fn(|(x,)| Ok(x));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().multiple_results())
         .returns_fn(|_| Ok((1, 2, 3)));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().multiple_results_struct())
         .returns_fn(|_| Ok(((1, 2), (3, 4))));
 
@@ -124,22 +124,22 @@ async fn returns_fn() -> Result {
 async fn returns_fn_ctx() -> Result {
     let contract = Mock::new(1234).deploy(AbiTypes::raw_contract().abi.clone());
 
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().get_void())
         .returns_fn_ctx(|_, _| Ok(()));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().get_u8())
         .returns_fn_ctx(|_, _| Ok(42));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().abiv_2_struct())
         .returns_fn_ctx(|_, (x,)| Ok(x));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().abiv_2_array_of_struct())
         .returns_fn_ctx(|_, (x,)| Ok(x));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().multiple_results())
         .returns_fn_ctx(|_, _| Ok((1, 2, 3)));
-    let _ = contract
+    contract
         .expect(AbiTypes::signatures().multiple_results_struct())
         .returns_fn_ctx(|_, _| Ok(((1, 2), (3, 4))));
 

--- a/ethcontract/src/int.rs
+++ b/ethcontract/src/int.rs
@@ -137,6 +137,7 @@ impl I256 {
     /// Coerces an unsigned integer into a signed one. If the unsigned integer
     /// is greater than the greater than or equal to `1 << 255`, then the result
     /// will overflow into a negative value.
+    #[must_use]
     pub fn from_raw(raw: U256) -> Self {
         I256(raw)
     }
@@ -144,46 +145,55 @@ impl I256 {
     /// Returns the signed integer as a unsigned integer. If the value of `self`
     /// negative, then the two's complement of its absolute value will be
     /// returned.
+    #[must_use]
     pub fn into_raw(self) -> U256 {
         self.0
     }
 
     /// Conversion to i32
+    #[must_use]
     pub fn low_i32(&self) -> i32 {
         self.0.low_u32() as _
     }
 
     /// Conversion to u32
+    #[must_use]
     pub fn low_u32(&self) -> u32 {
         self.0.low_u32()
     }
 
     /// Conversion to i64
+    #[must_use]
     pub fn low_i64(&self) -> i64 {
         self.0.low_u64() as _
     }
 
     /// Conversion to u64
+    #[must_use]
     pub fn low_u64(&self) -> u64 {
         self.0.low_u64() as _
     }
 
     /// Conversion to i128
+    #[must_use]
     pub fn low_i128(&self) -> i128 {
         self.0.low_u128() as _
     }
 
     /// Conversion to u128
+    #[must_use]
     pub fn low_u128(&self) -> u128 {
         self.0.low_u128() as _
     }
 
     /// Conversion to i128
+    #[must_use]
     pub fn low_isize(&self) -> isize {
         self.0.low_u64() as _
     }
 
     /// Conversion to usize
+    #[must_use]
     pub fn low_usize(&self) -> usize {
         self.0.low_u64() as _
     }
@@ -193,6 +203,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`i32::MIN`, `i32::MAX`].
+    #[must_use]
     pub fn as_i32(&self) -> i32 {
         (*self).try_into().unwrap()
     }
@@ -202,6 +213,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`0`, `u32::MAX`].
+    #[must_use]
     pub fn as_u32(&self) -> u32 {
         (*self).try_into().unwrap()
     }
@@ -211,6 +223,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`i64::MIN`, `i64::MAX`].
+    #[must_use]
     pub fn as_i64(&self) -> i64 {
         (*self).try_into().unwrap()
     }
@@ -220,6 +233,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`0`, `u64::MAX`].
+    #[must_use]
     pub fn as_u64(&self) -> u64 {
         (*self).try_into().unwrap()
     }
@@ -229,6 +243,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`i128::MIN`, `i128::MAX`].
+    #[must_use]
     pub fn as_i128(&self) -> i128 {
         (*self).try_into().unwrap()
     }
@@ -238,6 +253,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`0`, `u128::MAX`].
+    #[must_use]
     pub fn as_u128(&self) -> u128 {
         (*self).try_into().unwrap()
     }
@@ -247,6 +263,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`isize::MIN`, `isize::MAX`].
+    #[must_use]
     pub fn as_isize(&self) -> usize {
         (*self).try_into().unwrap()
     }
@@ -256,6 +273,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the number is outside the range [`0`, `usize::MAX`].
+    #[must_use]
     pub fn as_usize(&self) -> usize {
         (*self).try_into().unwrap()
     }
@@ -321,18 +339,21 @@ impl I256 {
 
     /// Returns `true` if `self` is positive and `false` if the number is zero
     /// or negative.
+    #[must_use]
     pub fn is_positive(self) -> bool {
         self.signum64().is_positive()
     }
 
     /// Returns `true` if `self` is negative and `false` if the number is zero
     /// or negative.
+    #[must_use]
     pub fn is_negative(self) -> bool {
         self.signum64().is_negative()
     }
 
     /// Returns `true` if `self` is negative and `false` if the number is zero
     /// or positive.
+    #[must_use]
     pub fn is_zero(self) -> bool {
         self.0.is_zero()
     }
@@ -354,6 +375,7 @@ impl I256 {
     /// (e.g., `I256::MIN` for values of type `I256`), then the minimum value
     /// will be returned again and true will be returned for an overflow
     /// happening.
+    #[must_use]
     pub fn overflowing_abs(self) -> (Self, bool) {
         if self == I256::MIN {
             (self, true)
@@ -364,6 +386,7 @@ impl I256 {
 
     /// Checked absolute value. Computes `self.abs()`, returning `None` if
     /// `self == MIN`.
+    #[must_use]
     pub fn checked_abs(self) -> Option<Self> {
         let (result, overflow) = self.overflowing_abs();
         if overflow {
@@ -400,6 +423,7 @@ impl I256 {
     /// indicating whether an overflow happened. If `self` is the minimum value,
     /// then the minimum value will be returned again and `true` will be
     /// returned for an overflow happening.
+    #[must_use]
     pub fn overflowing_neg(self) -> (Self, bool) {
         if self == I256::MIN {
             (self, true)
@@ -410,6 +434,7 @@ impl I256 {
 
     /// Checked negation. Computes `self.neg()`, returning `None` if
     /// `self == MIN`.
+    #[must_use]
     pub fn checked_neg(self) -> Option<Self> {
         let (result, overflow) = self.overflowing_neg();
         if overflow {
@@ -435,6 +460,7 @@ impl I256 {
     }
 
     /// Return the least number of bits needed to represent the number.
+    #[must_use]
     pub fn bits(&self) -> u32 {
         let unsigned = self.abs_unsigned();
         let unsigned_bits = unsigned.bits();
@@ -469,28 +495,33 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if index exceeds the bit width of the number.
+    #[must_use]
     pub fn bit(&self, index: usize) -> bool {
         self.0.bit(index)
     }
 
     /// Returns the number of ones in the binary representation of `self`.
+    #[must_use]
     pub fn count_ones(&self) -> u32 {
         (self.0).0.iter().map(|word| word.count_ones()).sum()
     }
 
     /// Returns the number of zeros in the binary representation of `self`.
+    #[must_use]
     pub fn count_zeros(&self) -> u32 {
         (self.0).0.iter().map(|word| word.count_zeros()).sum()
     }
 
     /// Returns the number of leading zeros in the binary representation of
     /// `self`.
+    #[must_use]
     pub fn leading_zeros(&self) -> u32 {
         self.0.leading_zeros()
     }
 
     /// Returns the number of leading zeros in the binary representation of
     /// `self`.
+    #[must_use]
     pub fn trailing_zeros(&self) -> u32 {
         self.0.trailing_zeros()
     }
@@ -500,6 +531,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if index exceeds the byte width of the number.
+    #[must_use]
     pub fn byte(&self, index: usize) -> u8 {
         self.0.byte(index)
     }
@@ -521,6 +553,7 @@ impl I256 {
     /// Returns a tuple of the addition along with a boolean indicating whether
     /// an arithmetic overflow would occur. If an overflow would have occurred
     /// then the wrapped value is returned.
+    #[must_use]
     pub fn overflowing_add(self, rhs: Self) -> (Self, bool) {
         let (unsigned, _) = self.0.overflowing_add(rhs.0);
         let result = I256(unsigned);
@@ -537,6 +570,7 @@ impl I256 {
     }
 
     /// Checked addition. Returns None if overflow occurred.
+    #[must_use]
     pub fn checked_add(self, other: Self) -> Option<Self> {
         let (result, overflow) = self.overflowing_add(other);
         if overflow {
@@ -572,6 +606,7 @@ impl I256 {
     /// Returns a tuple of the subtraction along with a boolean indicating
     /// whether an arithmetic overflow would occur. If an overflow would have
     /// occurred then the wrapped value is returned.
+    #[must_use]
     pub fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
         // NOTE: We can't just compute the `self + (-rhs)` because `-rhs` does
         //   not always exist, specifically this would be a problem in case
@@ -592,6 +627,7 @@ impl I256 {
     }
 
     /// Checked subtraction. Returns None if overflow occurred.
+    #[must_use]
     pub fn checked_sub(self, other: Self) -> Option<Self> {
         let (result, overflow) = self.overflowing_sub(other);
         if overflow {
@@ -627,6 +663,7 @@ impl I256 {
     /// Returns a tuple of the multiplication along with a boolean indicating
     /// whether an arithmetic overflow would occur. If an overflow would have
     /// occurred then the wrapped value is returned.
+    #[must_use]
     pub fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
         let sign = Sign::from_signum64(self.signum64() * rhs.signum64());
         let (unsigned, overflow_mul) = self.abs_unsigned().overflowing_mul(rhs.abs_unsigned());
@@ -636,6 +673,7 @@ impl I256 {
     }
 
     /// Checked multiplication. Returns None if overflow occurred.
+    #[must_use]
     pub fn checked_mul(self, other: Self) -> Option<Self> {
         let (result, overflow) = self.overflowing_mul(other);
         if overflow {
@@ -668,6 +706,7 @@ impl I256 {
     /// Returns a tuple of the division along with a boolean indicating
     /// whether an arithmetic overflow would occur. If an overflow would have
     /// occurred then the wrapped value is returned.
+    #[must_use]
     pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
         // Panic early when with division by zero while evaluating sign.
         let sign = Sign::from_signum64(self.signum64() / rhs.signum64());
@@ -679,6 +718,7 @@ impl I256 {
     }
 
     /// Checked division. Returns None if overflow occurred or if rhs == 0.
+    #[must_use]
     pub fn checked_div(self, rhs: Self) -> Option<Self> {
         if rhs == I256::zero() || (self == Self::min_value() && rhs == -I256::one()) {
             None
@@ -705,6 +745,7 @@ impl I256 {
     /// Returns a tuple of the remainder along with a boolean indicating
     /// whether an arithmetic overflow would occur. If an overflow would have
     /// occurred then the wrapped value is returned.
+    #[must_use]
     pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
         if self == Self::MIN && rhs == Self::from(-1) {
             (Self::zero(), true)
@@ -715,6 +756,7 @@ impl I256 {
     }
 
     /// Checked remainder. Returns None if overflow occurred or rhs == 0
+    #[must_use]
     pub fn checked_rem(self, rhs: Self) -> Option<Self> {
         if rhs == I256::zero() || (self == Self::min_value() && rhs == -I256::one()) {
             None
@@ -770,6 +812,7 @@ impl I256 {
     /// Calculates the quotient of Euclidean division `self.div_euclid(rhs)`.
     /// Returns a tuple of the divisor along with a boolean indicating whether an arithmetic
     /// overflow would occur. If an overflow would occur then `self` is returned.
+    #[must_use]
     pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
         if self == Self::min_value() && rhs == -I256::one() {
             (self, true)
@@ -780,6 +823,7 @@ impl I256 {
 
     /// Checked Euclidean division. Computes `self.div_euclid(rhs)`,
     /// returning None if `rhs == 0` or the division results in overflow.
+    #[must_use]
     pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
         if rhs == I256::zero() || (self == Self::min_value() && rhs == -I256::one()) {
             None
@@ -803,6 +847,7 @@ impl I256 {
     /// Returns a tuple of the remainder after dividing along with a boolean indicating whether
     /// an arithmetic overflow would occur. If an overflow would occur then `0` is returned.
     /// Panics if `rhs == 0`
+    #[must_use]
     pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
         if self == Self::min_value() && rhs == -Self::one() {
             (Self::zero(), true)
@@ -824,6 +869,7 @@ impl I256 {
 
     /// Checked Euclidean remainder. Computes `self.rem_euclid(rhs)`,
     /// returning `None` if `rhs == 0` or the division results in overflow.
+    #[must_use]
     pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
         if rhs == I256::zero() || (self == Self::min_value() && rhs == -I256::one()) {
             None
@@ -853,6 +899,7 @@ impl I256 {
     /// # Panics
     ///
     /// Panics if the result overflows the type.
+    #[must_use]
     pub fn exp10(n: usize) -> Self {
         U256::exp10(n).try_into().expect("overflow")
     }
@@ -871,6 +918,7 @@ impl I256 {
     ///
     /// Returns a tuple of the exponentiation along with a bool indicating
     /// whether an overflow happened.
+    #[must_use]
     pub fn overflowing_pow(self, exp: u32) -> (Self, bool) {
         let sign = self.pow_sign(exp);
         let (unsigned, overflow_pow) = self.abs_unsigned().overflowing_pow(exp.into());
@@ -880,6 +928,7 @@ impl I256 {
     }
 
     /// Raises self to the power of `exp`. Returns None if overflow occurred.
+    #[must_use]
     pub fn checked_pow(self, exp: u32) -> Option<Self> {
         let (result, overflow) = self.overflowing_pow(exp);
         if overflow {

--- a/ethcontract/src/transaction/confirm.rs
+++ b/ethcontract/src/transaction/confirm.rs
@@ -17,6 +17,7 @@ use web3::Transport;
 
 /// A struct with the confirmation parameters.
 #[derive(Clone, Debug)]
+#[must_use = "confirm parameters do nothing unless waited for"]
 pub struct ConfirmParams {
     /// The number of blocks to confirm the transaction with. This is the number
     /// of blocks mined on top of the block where the transaction was mined.
@@ -83,7 +84,6 @@ impl ConfirmParams {
     ///
     /// [`confirmations`]: #structfield.confirmations
     #[inline]
-    #[must_use]
     pub fn confirmations(mut self, confirmations: usize) -> Self {
         self.confirmations = confirmations;
         self
@@ -91,7 +91,6 @@ impl ConfirmParams {
 
     /// Set new values for exponential backoff settings.
     #[inline]
-    #[must_use]
     pub fn poll_interval(mut self, min: Duration, max: Duration, factor: f32) -> Self {
         self.poll_interval_min = min;
         self.poll_interval_max = max;
@@ -103,7 +102,6 @@ impl ConfirmParams {
     ///
     /// [`poll_interval_min`]: #structfield.poll_interval_min
     #[inline]
-    #[must_use]
     pub fn poll_interval_min(mut self, poll_interval_min: Duration) -> Self {
         self.poll_interval_min = poll_interval_min;
         self
@@ -113,7 +111,6 @@ impl ConfirmParams {
     ///
     /// [`poll_interval_max`]: #structfield.poll_interval_max
     #[inline]
-    #[must_use]
     pub fn poll_interval_max(mut self, poll_interval_max: Duration) -> Self {
         self.poll_interval_max = poll_interval_max;
         self
@@ -123,7 +120,6 @@ impl ConfirmParams {
     ///
     /// [`poll_interval_factor`]: #structfield.poll_interval_factor
     #[inline]
-    #[must_use]
     pub fn poll_interval_factor(mut self, poll_interval_factor: f32) -> Self {
         self.poll_interval_factor = poll_interval_factor;
         self
@@ -133,7 +129,6 @@ impl ConfirmParams {
     ///
     /// [`block_timeout`]: #structfield.block_timeout
     #[inline]
-    #[must_use]
     pub fn block_timeout(mut self, block_timeout: Option<usize>) -> Self {
         self.block_timeout = block_timeout;
         self


### PR DESCRIPTION
Some `must_use` attributes were introduced in #695, this PR proposes some changes to them. Namely:
- For builder types, it makes more sense to add it to the type and not each method. This also allows us to add some context on why it must be used with less code duplication
- For `I256` it was only added to some methods, but not others. This is because the `clippy` on nightly didn't catch all the cases. To be consistent with standard library numerical types, I added `must_use` on the other methods that need it as well. There are 4 exceptions:
  - `from_dec_str`/`from_hex_str`: These return `Result`s which already are `must_use`
  - `to_big_endian`/`to_little_endian`: These mutate a `&mut [u8]` parameter that is passed in and don't return anything, so `must_use` didn't make sense
- Removed `must_use` for the `mock::Expectation` type. This was a breaking change that I didn't agree with. Specifically, these expectation methods did have side effects and returned `Self` as a convenience to chain calls. `must_use` didn't make sense here. Instead I silenced the warning. Note that the lint that caused these changes is `return_self_not_must_use` which is not available on stable Rust yet. This required an additional silencing of `unknown_lints` lint. For this particular case, I'd be slightly more in favour to just remove the lint and allow the nightly build to ❌ for now. WDYT?

### Test Plan

Rust compiler. No real logic changes.
