### PR TITLE
Put GasPrice module under a feature

### DIFF
--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -33,6 +33,7 @@ ipc-tokio = ["web3/ipc-tokio"]
 arrayvec = "0.7"
 ethcontract-common = { version = "0.15.4", path = "../ethcontract-common" }
 ethcontract-derive = { version = "0.15.4", path = "../ethcontract-derive", optional = true}
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.4.0"}
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -17,7 +17,8 @@ to Ethereum smart contracts.
 name = "ethcontract"
 
 [features]
-default = ["derive", "http-tls", "ws-tls-tokio"]
+default = ["derive", "http-tls", "ws-tls-tokio", "gas_price"]
+gas_price = ["primitive-types", "web3"]
 derive = ["ethcontract-derive"]
 http = ["web3/http"]
 http-tls = ["http", "web3/http-tls"]
@@ -39,13 +40,13 @@ futures-timer = "3.0"
 hex = "0.4"
 jsonrpc-core = "18.0"
 lazy_static = "1.4"
-primitive-types = { version = "0.10", features = ["fp-conversion"] }
+primitive-types = { version = "0.10", features = ["fp-conversion"], optional = true }
 secp256k1 = { version = "0.20", features = ["recovery"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 uint = "0.9"
-web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c7aede4d2c2828f7267d79227e", default-features = false, features = ["signing"] }
+web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev="a425fa747bca69c7aede4d2c2828f7267d79227e", default-features = false, features = ["signing"], optional = true }
 zeroize = "1.1"
 
 [dev-dependencies]

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -34,7 +34,6 @@ ipc-tokio = ["web3/ipc-tokio"]
 arrayvec = "0.7"
 ethcontract-common = { version = "0.15.4", path = "../ethcontract-common" }
 ethcontract-derive = { version = "0.15.4", path = "../ethcontract-derive", optional = true}
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.4.0"}
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"

--- a/ethcontract/src/transaction.rs
+++ b/ethcontract/src/transaction.rs
@@ -3,6 +3,7 @@
 
 mod build;
 pub mod confirm;
+#[cfg(feature = "gas_price")]
 pub mod gas_price;
 mod send;
 

--- a/ethcontract/src/transaction/gas_price.rs
+++ b/ethcontract/src/transaction/gas_price.rs
@@ -2,7 +2,6 @@
 
 use primitive_types::U256;
 use web3::types::U64;
-use gas_estimation::EstimatedGasPrice;
 
 #[derive(Debug, Default, PartialEq)]
 /// Data related to gas price, prepared for populating the transaction object.

--- a/ethcontract/src/transaction/gas_price.rs
+++ b/ethcontract/src/transaction/gas_price.rs
@@ -1,8 +1,8 @@
 //! Implementation of gas price estimation.
 
-use gas_estimation::EstimatedGasPrice;
 use primitive_types::U256;
 use web3::types::U64;
+use gas_estimation::EstimatedGasPrice;
 
 #[derive(Debug, Default, PartialEq)]
 /// Data related to gas price, prepared for populating the transaction object.
@@ -79,16 +79,6 @@ impl From<(U256, U256)> for GasPrice {
 impl From<(f64, f64)> for GasPrice {
     fn from(value: (f64, f64)) -> Self {
         (U256::from_f64_lossy(value.0), U256::from_f64_lossy(value.1)).into()
-    }
-}
-
-impl From<EstimatedGasPrice> for GasPrice {
-    fn from(gas_price: EstimatedGasPrice) -> Self {
-        if let Some(eip1559) = gas_price.eip1559 {
-            (eip1559.max_fee_per_gas, eip1559.max_priority_fee_per_gas).into()
-        } else {
-            gas_price.legacy.into()
-        }
     }
 }
 

--- a/ethcontract/src/transaction/gas_price.rs
+++ b/ethcontract/src/transaction/gas_price.rs
@@ -2,6 +2,7 @@
 
 use primitive_types::U256;
 use web3::types::U64;
+use gas_estimation::EstimatedGasPrice;
 
 #[derive(Debug, Default, PartialEq)]
 /// Data related to gas price, prepared for populating the transaction object.
@@ -78,6 +79,16 @@ impl From<(U256, U256)> for GasPrice {
 impl From<(f64, f64)> for GasPrice {
     fn from(value: (f64, f64)) -> Self {
         (U256::from_f64_lossy(value.0), U256::from_f64_lossy(value.1)).into()
+    }
+}
+
+impl From<EstimatedGasPrice> for GasPrice {
+    fn from(gas_price: EstimatedGasPrice) -> Self {
+        if let Some(eip1559) = gas_price.eip1559 {
+            (eip1559.max_fee_per_gas, eip1559.max_priority_fee_per_gas).into()
+        } else {
+            gas_price.legacy.into()
+        }
     }
 }
 

--- a/ethcontract/src/transaction/gas_price.rs
+++ b/ethcontract/src/transaction/gas_price.rs
@@ -1,8 +1,8 @@
 //! Implementation of gas price estimation.
 
+use gas_estimation::EstimatedGasPrice;
 use primitive_types::U256;
 use web3::types::U64;
-use gas_estimation::EstimatedGasPrice;
 
 #[derive(Debug, Default, PartialEq)]
 /// Data related to gas price, prepared for populating the transaction object.


### PR DESCRIPTION
~~Added conversion from EstimatedGasPrice to GasPrice.
This conversion is used in multiple places in gp-v2-services repo, thus this PR will reduce code duplication.~~

~~Planning to merge regardless of clippy errors (probably consequence of the Rust outdated version)~~

This PR puts GasPrice under a feature, so only its definition could be imported into gp-gas-estimation repo