### PR TITLE
deploy with address

### DIFF
--- a/ethcontract-mock/src/details/mod.rs
+++ b/ethcontract-mock/src/details/mod.rs
@@ -102,7 +102,8 @@ impl MockTransport {
                 .contracts
                 .insert(address, Contract::new(address, abi))
                 .is_none(),
-            "replacing contract at address {address:?}",
+            "replacing contract at address {:?}",
+            address
         );
     }
 

--- a/ethcontract-mock/src/details/mod.rs
+++ b/ethcontract-mock/src/details/mod.rs
@@ -97,7 +97,13 @@ impl MockTransport {
     pub fn deploy_with_address(&self, abi: &Abi, address: Address) {
         let mut state = self.state.lock().unwrap();
 
-        state.contracts.insert(address, Contract::new(address, abi));
+        assert!(
+            state
+                .contracts
+                .insert(address, Contract::new(address, abi))
+                .is_none(),
+            "replacing contract at address {address:?}",
+        );
     }
 
     pub fn update_gas_price(&self, gas_price: u64) {

--- a/ethcontract-mock/src/details/mod.rs
+++ b/ethcontract-mock/src/details/mod.rs
@@ -93,6 +93,13 @@ impl MockTransport {
         address
     }
 
+    /// Deploys a new contract with the given ABI and address
+    pub fn deploy_with_address(&self, abi: &Abi, address: Address) {
+        let mut state = self.state.lock().unwrap();
+
+        state.contracts.insert(address, Contract::new(address, abi));
+    }
+
     pub fn update_gas_price(&self, gas_price: u64) {
         let mut state = self.state.lock().unwrap();
         state.gas_price = gas_price;

--- a/ethcontract-mock/src/lib.rs
+++ b/ethcontract-mock/src/lib.rs
@@ -289,6 +289,17 @@ impl Mock {
         }
     }
 
+    /// Deploys a new mocked contract with specified address and returns an object that allows
+    /// configuring expectations for contract methods.
+    pub fn deploy_with_address(&self, abi: Abi, address: Address) -> Contract {
+        self.transport.deploy_with_address(&abi, address);
+        Contract {
+            transport: self.transport.clone(),
+            address,
+            abi,
+        }
+    }
+
     /// Updates gas price that is returned by RPC call `eth_gasPrice`.
     ///
     /// Mock node does not simulate gas consumption, so this value does not


### PR DESCRIPTION
This PR adds possibility to deploy new contracts to the network using the custom contract address instead of using the internal counter for automatic address generation.