### PR TITLE
Add event source

### DIFF
--- a/ethcontract-mock/src/details/mod.rs
+++ b/ethcontract-mock/src/details/mod.rs
@@ -64,6 +64,7 @@ struct MockTransportState {
     receipts: HashMap<H256, TransactionReceipt>,
 }
 
+#[allow(clippy::type_complexity)]
 impl MockTransport {
     /// Creates a new transport.
     pub fn new(chain_id: u64) -> Self {
@@ -1007,7 +1008,7 @@ impl<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> ExpectationApi
     }
 }
 
-#[allow(clippy::enum_variant_names)]
+#[allow(clippy::enum_variant_names, clippy::type_complexity)]
 enum Predicate<P: Tokenize + Send + 'static> {
     None,
     Predicate(Box<dyn predicates::Predicate<P> + Send>),
@@ -1026,6 +1027,7 @@ impl<P: Tokenize + Send + 'static> Predicate<P> {
     }
 }
 
+#[allow(clippy::type_complexity)]
 enum Returns<P: Tokenize + Send + 'static, R: Tokenize + Send + 'static> {
     Default,
     Error(String),

--- a/ethcontract/src/contract/event/data.rs
+++ b/ethcontract/src/contract/event/data.rs
@@ -1,7 +1,7 @@
 //! Module contains code for parsing and manipulating event data.
 use crate::{errors::ExecutionError, tokens::Tokenize};
 use ethcontract_common::abi::{Event as AbiEvent, RawLog as AbiRawLog, Token};
-use web3::types::{Log, H256};
+use web3::types::{Log, H160, H256};
 
 /// A contract event
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -125,6 +125,8 @@ impl<T> Event<EventStatus<T>> {
 /// Additional metadata from the log for the event.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EventMetadata {
+    /// From which this event originated from
+    pub address: H160,
     /// The hash of the block where the log was produced.
     pub block_hash: H256,
     /// The number of the block where the log was produced.
@@ -146,6 +148,7 @@ pub struct EventMetadata {
 impl EventMetadata {
     fn from_log(log: &Log) -> Option<Self> {
         Some(EventMetadata {
+            address: log.address,
             block_hash: log.block_hash?,
             block_number: log.block_number?.as_u64(),
             transaction_hash: log.transaction_hash?,


### PR DESCRIPTION
This PR adds the event issuer to event metadata.

This is needed when user is subscribed to events from multiple different contract addresses at the same time. Without address, it cant know which contract raised the event.