### PR TITLE
Add deployed bytecode to contract artifact

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -56,6 +56,7 @@ jobs:
             cargo run --package examples --example abi
             cargo run --package examples --example async
             cargo run --package examples --example batch
+            cargo run --package examples --example bytecode
             cargo run --package examples --example deployments
             cargo run --package examples --example events
             cargo run --package examples --example revert

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ makes a method call.
 cargo run --example linked
 ```
 
+#### Deployed Bytecode
+
+The `bytecode` example deploys a contract and verifies its bytecode matches the
+expected value from the contract artifact.
+
+```sh
+cargo run --example bytecode
+```
+
 ### Rinkeby Example
 
 There is a provided example that runs with Rinkeby and Infura. Running this

--- a/ethcontract-common/src/artifact.rs
+++ b/ethcontract-common/src/artifact.rs
@@ -159,6 +159,11 @@ impl<'a> ContractMut<'a> {
         &mut self.0.bytecode
     }
 
+    /// Returns mutable reference to contract's bytecode.
+    pub fn deployed_bytecode_mut(&mut self) -> &mut Bytecode {
+        &mut self.0.deployed_bytecode
+    }
+
     /// Returns mutable reference to contract's networks.
     pub fn networks_mut(&mut self) -> &mut HashMap<String, Network> {
         &mut self.0.networks

--- a/ethcontract-common/src/contract.rs
+++ b/ethcontract-common/src/contract.rs
@@ -17,6 +17,9 @@ pub struct Contract {
     pub abi: Abi,
     /// The contract deployment bytecode.
     pub bytecode: Bytecode,
+    /// The contract's expected deployed bytecode.
+    #[serde(rename = "deployedBytecode")]
+    pub deployed_bytecode: Bytecode,
     /// The configured networks by network ID for the contract.
     pub networks: HashMap<String, Network>,
     /// The developer documentation.
@@ -37,6 +40,7 @@ impl Contract {
             name: name.into(),
             abi: Default::default(),
             bytecode: Default::default(),
+            deployed_bytecode: Default::default(),
             networks: HashMap::new(),
             devdoc: Default::default(),
             userdoc: Default::default(),

--- a/examples/examples/bytecode.rs
+++ b/examples/examples/bytecode.rs
@@ -1,0 +1,30 @@
+use ethcontract::prelude::*;
+
+ethcontract::contract!("examples/truffle/build/contracts/RustCoin.json");
+
+#[tokio::main]
+async fn main() {
+    let http = Http::new("http://localhost:9545").expect("transport failed");
+    let web3 = Web3::new(http);
+
+    let instance = RustCoin::builder(&web3)
+        .gas(4_712_388.into())
+        .deploy()
+        .await
+        .expect("deployment failed");
+
+    let code = web3
+        .eth()
+        .code(instance.address(), None)
+        .await
+        .expect("get code failed");
+    assert_eq!(
+        code,
+        RustCoin::raw_contract()
+            .deployed_bytecode
+            .to_bytes()
+            .expect("failed to read contract deployed bytecode"),
+    );
+
+    println!("RustCoin deployment matches expected bytecode");
+}


### PR DESCRIPTION
This PR adds the `deployed_bytecode` property to the `Contract` loaded artifact. This allows users to do things like:
- Use `eth_call` with storage overrides for contracts.
- Verify that the on-chain bytecode matches the expected deployed bytecode value.

The main motivation for this change is that we intent on starting to use `eth_call`s for state overrides in Cow Protocol services, and having it be parsed with the contract artifact makes sense.

### Test Plan

Added a new example that tests that the deployed bytecode data in the contract artifact is working.
