### PR TITLE
Ignore clippy type complexity errors in build contracts

### DIFF
--- a/ethcontract-generate/src/generate.rs
+++ b/ethcontract-generate/src/generate.rs
@@ -131,6 +131,7 @@ fn expand_contract(cx: &Context) -> Result<TokenStream> {
 
     Ok(quote! {
         #[allow(dead_code)]
+        #[allow(clippy::type_complexity)]
         #vis mod #contract_mod {
             #[rustfmt::skip]
             use #runtime_crate as ethcontract;

--- a/ethcontract-generate/src/generate.rs
+++ b/ethcontract-generate/src/generate.rs
@@ -130,8 +130,7 @@ fn expand_contract(cx: &Context) -> Result<TokenStream> {
     let events = events::expand(cx)?;
 
     Ok(quote! {
-        #[allow(dead_code)]
-        #[allow(clippy::type_complexity)]
+        #[allow(dead_code, clippy::type_complexity)]
         #vis mod #contract_mod {
             #[rustfmt::skip]
             use #runtime_crate as ethcontract;


### PR DESCRIPTION
Smart contracts can have functions or events with a higher type complexity than allowed by clippy. Hence, we need to add the allow statement. 