### PR TITLE
Add blockhash to event filter

### DIFF
--- a/ethcontract-generate/src/rustfmt.rs
+++ b/ethcontract-generate/src/rustfmt.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Stdio};
 /// Formats the raw input source string and return formatted output.
 pub fn format(source: &str) -> Result<String> {
     let mut rustfmt = Command::new("rustfmt")
-        .args(&["--edition", "2018"])
+        .args(["--edition", "2018"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()?;

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -271,7 +271,7 @@ impl<T: Transport> Instance<T> {
             .events
             .get(&signature)
             .map(|(name, index)| &self.abi.events[name][*index])
-            .ok_or_else(|| AbiError::InvalidName(hex::encode(&signature)))?;
+            .ok_or_else(|| AbiError::InvalidName(hex::encode(signature)))?;
 
         Ok(EventBuilder::new(
             self.web3(),

--- a/ethcontract/src/contract/event.rs
+++ b/ethcontract/src/contract/event.rs
@@ -213,6 +213,13 @@ impl<T: Transport, E: ParseLog> AllEventsBuilder<T, E> {
         self
     }
 
+    /// Sets `block_hash`. The field `block_hash` and the pair `from_block` and
+    /// `to_block` are mutually exclusive.
+    pub fn block_hash(mut self, hash: H256) -> Self {
+        self.filter = self.filter.block_hash(hash);
+        self
+    }
+
     /// Adds a filter for the first indexed topic.
     ///
     /// For regular events, this corresponds to the event signature. For

--- a/ethcontract/src/errors/parity.rs
+++ b/ethcontract/src/errors/parity.rs
@@ -17,7 +17,7 @@ pub fn get_encoded_error(err: &JsonrpcError) -> Option<ExecutionError> {
         if hex.is_empty() {
             return Some(ExecutionError::Revert(None));
         } else {
-            let bytes = hex::decode(&hex).ok()?;
+            let bytes = hex::decode(hex).ok()?;
             let reason = revert::decode_reason(&bytes)?;
             return Some(ExecutionError::Revert(Some(reason)));
         }

--- a/ethcontract/src/log.rs
+++ b/ethcontract/src/log.rs
@@ -35,6 +35,8 @@ pub struct LogFilterBuilder<T: Transport> {
     ///
     /// See [`web3::types::BlockNumber`] for more details on possible values.
     pub to_block: Option<BlockNumber>,
+    /// Block hash, mutually exclusive with pair `from_block` / `to_block`.
+    pub block_hash: Option<H256>,
     /// The contract addresses to filter logs for.
     pub address: Vec<Address>,
     /// Topic filters used for filtering logs based on indexed topics.
@@ -64,6 +66,7 @@ impl<T: Transport> LogFilterBuilder<T> {
             limit: None,
             block_page_size: None,
             poll_interval: None,
+            block_hash: None,
         }
     }
 
@@ -82,6 +85,13 @@ impl<T: Transport> LogFilterBuilder<T> {
     #[allow(clippy::wrong_self_convention)]
     pub fn to_block(mut self, block: BlockNumber) -> Self {
         self.to_block = Some(block);
+        self
+    }
+
+    /// Sets `block_hash`. The field `block_hash` and the pair `from_block` and
+    /// `to_block` are mutually exclusive.
+    pub fn block_hash(mut self, hash: H256) -> Self {
+        self.block_hash = Some(hash);
         self
     }
 
@@ -153,6 +163,9 @@ impl<T: Transport> LogFilterBuilder<T> {
         }
         if let Some(to_block) = self.to_block {
             filter = filter.to_block(to_block);
+        }
+        if let Some(hash) = self.block_hash {
+            filter = filter.block_hash(hash);
         }
         if !self.address.is_empty() {
             filter = filter.address(self.address);

--- a/ethcontract/src/secret.rs
+++ b/ethcontract/src/secret.rs
@@ -21,7 +21,7 @@ pub struct PrivateKey(Zeroizing<ZeroizeableSecretKey>);
 impl PrivateKey {
     /// Creates a new private key from raw bytes.
     pub fn from_raw(raw: [u8; 32]) -> Result<Self, InvalidPrivateKey> {
-        PrivateKey::from_slice(&raw)
+        PrivateKey::from_slice(raw)
     }
 
     /// Creates a new private key from a slice of bytes.


### PR DESCRIPTION
Adds possibility to filter events by block_hash.
Needed for https://github.com/cowprotocol/services/pull/535 

Additionally some clippy fixes.
