### PR TITLE
Allow large_enum_variants

### DIFF
--- a/ethcontract-generate/src/generate.rs
+++ b/ethcontract-generate/src/generate.rs
@@ -130,7 +130,7 @@ fn expand_contract(cx: &Context) -> Result<TokenStream> {
     let events = events::expand(cx)?;
 
     Ok(quote! {
-        #[allow(dead_code, clippy::type_complexity)]
+        #[allow(dead_code, clippy::type_complexity, clippy::large_enum_variant)]
         #vis mod #contract_mod {
             #[rustfmt::skip]
             use #runtime_crate as ethcontract;

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -14,7 +14,7 @@ Tools for mocking ethereum contracts.
 [dependencies]
 ethcontract = { version = "0.22.0", path = "../ethcontract", default-features = false, features = ["derive"] }
 hex = "0.4"
-mockall = "0.11"
+mockall = "0.11.2"
 rlp = "0.5"
 predicates = "2.0"
 

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -14,7 +14,7 @@ Tools for mocking ethereum contracts.
 [dependencies]
 ethcontract = { version = "0.22.0", path = "../ethcontract", default-features = false, features = ["derive"] }
 hex = "0.4"
-mockall = "0.11.2"
+mockall = "0.11"
 rlp = "0.5"
 predicates = "2.0"
 


### PR DESCRIPTION
Fixes [#issue](https://github.com/gnosis/ethcontract-rs/issues/854)

This is just the most straightforward thing to do. I think at some point in time, it might make sense to impl the suggestion from the compiler. But I don't wanna block the ethflow project by it.

### Test Plan
non
(If I add this clippy allow it in my Contract.rs of the ethflow contract, I can compile without clippy warnings)