### PR TITLE
Able to process foundry ABI

### DIFF
--- a/ethcontract-common/src/bytecode.rs
+++ b/ethcontract-common/src/bytecode.rs
@@ -24,7 +24,7 @@ impl Bytecode {
             return Ok(Bytecode::default());
         }
 
-        let s = if s.chars().next().unwrap() == '{' {
+        let s = if s.starts_with('{') {
             #[derive(Deserialize)]
             struct Map {
                 object: String,

--- a/ethcontract-common/src/bytecode.rs
+++ b/ethcontract-common/src/bytecode.rs
@@ -17,12 +17,23 @@ use web3::types::{Address, Bytes};
 pub struct Bytecode(String);
 
 impl Bytecode {
-    /// Reads hex bytecode representation from a string slice.
+    /// Reads hex bytecode representation from a string or map slice.
     pub fn from_hex_str(s: &str) -> Result<Self, BytecodeError> {
         if s.is_empty() {
             // special case where we have an empty string byte code.
             return Ok(Bytecode::default());
         }
+
+        let s = if s.chars().next().unwrap() == '{' {
+            #[derive(Deserialize)]
+            struct Map {
+                object: String,
+            }
+            let map: Map = serde_json::from_str(s).map_err(|_| BytecodeError::InvalidMapStruct)?;
+            map.object
+        } else {
+            s.to_string()
+        };
 
         // Verify that the length is even
         if s.len() % 2 != 0 {
@@ -30,7 +41,7 @@ impl Bytecode {
         }
 
         // account for optional 0x prefix
-        let s = s.strip_prefix("0x").unwrap_or(s);
+        let s = s.strip_prefix("0x").unwrap_or(&s);
 
         // verify that each code block is valid hex
         for block in CodeIter(s) {
@@ -202,6 +213,15 @@ mod tests {
     #[test]
     fn unprefixed_hex_bytecode_is_not_empty() {
         assert!(!Bytecode::from_hex_str("feedface").unwrap().is_empty());
+    }
+
+    #[test]
+    fn unprefixed_map_hex_bytecode_is_not_empty() {
+        assert!(!Bytecode::from_hex_str(
+            r#"{"object": "0x60e060"} "#
+        )
+        .unwrap()
+        .is_empty());
     }
 
     #[test]

--- a/ethcontract-common/src/bytecode.rs
+++ b/ethcontract-common/src/bytecode.rs
@@ -217,11 +217,9 @@ mod tests {
 
     #[test]
     fn unprefixed_map_hex_bytecode_is_not_empty() {
-        assert!(!Bytecode::from_hex_str(
-            r#"{"object": "0x60e060"} "#
-        )
-        .unwrap()
-        .is_empty());
+        assert!(!Bytecode::from_hex_str(r#"{"object": "0x60e060"} "#)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/ethcontract-common/src/errors.rs
+++ b/ethcontract-common/src/errors.rs
@@ -31,6 +31,10 @@ pub enum BytecodeError {
     #[error("invalid bytecode length")]
     InvalidLength,
 
+    /// Bytecode string is a map, but not accroding to official map format
+    #[error("invalid map for bytecode")]
+    InvalidMapStruct,
+
     /// Placeholder is not long enough at end of bytecode string.
     #[error("placeholder at end of bytecode is too short")]
     PlaceholderTooShort,


### PR DESCRIPTION
Foundry and hardhat have a very similar ABI format, but its not exactly the same. The bytecode in foundry is map, instead of just a string. I think the ABI are similar enough, such that we don't have provide another loader format to the existing ones of truffle/hardhat, but can just parse the ByteCode differently. 

Link to [hardhat ABI](https://raw.githubusercontent.com/cowprotocol/ethflowcontract/hardhatversion/build/artifacts/src/CoWSwapEthFlow.sol/CoWSwapEthFlow.json): 
Link to [foundry ABI](https://raw.githubusercontent.com/cowprotocol/ethflowcontract/v0.0.0-rc.1-artifacts/artifacts/CoWSwapEthFlow.sol/CoWSwapEthFlow.json)


### Test Plan
