### PR TITLE
Categorize Additional Nethermind Revert Error

### DIFF
--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This PR categorizes an additional Nethereum revert error so that we don't mis-classify them as a JSON RPC error.

I noticed it specifically here:
```
2022-11-28T14:37:54.819Z TRACE shared::ethrpc::http: received response name=base id=148680 body=[{"jsonrpc":"2.0","error":{"code":-32015,"message":"VM execution error.","data":"revert"},"id":148650},...
```

Where this RPC error was not being classified as a revert error:
```
2022-11-28T14:37:54.819Z  WARN request{id="733a0c1fa9fda1e0818ab7fa176d3d7a"}: shared::bad_token::instrumented: bad token detection for 0xb975debd497c1cc6cdcb9f4246ef4903e842671f returned error:
method 'balanceOf(address):(uint256)' failure: web3 error: RPC error: Error { code: ServerError(-32015), message: "VM execution error.", data: Some(String("revert")) }
```

### Test Plan

Added unit test to check that it works as expected.
