### PR TITLE
Improve Nethermind revert error detection

### DIFF
--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
It looks like Nethermind has a couple of flavours of revert error messages for different `eth_call` class RPC methods. This PR adjusts the error detection to account for both flavours.

Specifically, we now handle:
```
web3 error: RPC error: Error {
    code: ServerError(-32015),
    message: "Reverted 0x...",
    data: None,
}
```

### Test Plan

Added unit test cases.
