### PR TITLE
🤺😪

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.64.0
+          - rust: 1.65.0
             examples: false
             continue-on-error: false
           - rust: stable
@@ -35,6 +35,7 @@ jobs:
           components: rustfmt, clippy
           default: true
       - uses: Swatinem/rust-cache@v1
+      - uses: foundry-rs/foundry-toolchain@v1
       - run: cargo fmt -- --check
       - run: cd examples/truffle && yarn --frozen-lockfile && yarn build
       # Can't use --all-features here because web3 has mutually exclusive features.
@@ -48,8 +49,8 @@ jobs:
           (cd ethcontract-generate && cargo test)
       - run: |
           if ${{ matrix.examples }}; then
-            (cd examples/truffle && yarn -s run start > /dev/null) &
-            # wait for truffle to start
+            anvil-p 9545 &
+            # wait for anvil to start
             while ! curl --silent http://127.0.0.1:9545 -o /dev/null; do
               sleep 1
             done

--- a/ethcontract-generate/src/generate/events.rs
+++ b/ethcontract-generate/src/generate/events.rs
@@ -345,6 +345,8 @@ fn expand_builder_topic_filter(topic_index: usize, param: &EventParam) -> Result
     ));
     let topic = util::ident(&format!("topic{}", topic_index));
     let name = if param.name.is_empty() {
+        // Clippy is failing on github complaining that this clone isn't needed (despite topic clearly being used later)
+        #[allow(clippy::redundant_clone)]
         topic.clone()
     } else {
         util::safe_ident(&param.name.to_snake_case())

--- a/examples/examples/deployments.rs
+++ b/examples/examples/deployments.rs
@@ -3,7 +3,7 @@ use ethcontract::prelude::*;
 ethcontract::contract!(
     "examples/truffle/build/contracts/RustCoin.json",
     deployments {
-        5777 => "0x0123456789012345678901234567890123456789",
+        31337 => "0x0123456789012345678901234567890123456789",
     },
 );
 

--- a/examples/examples/revert.rs
+++ b/examples/examples/revert.rs
@@ -36,5 +36,5 @@ async fn main() {
     assert!(matches!(error, ExecutionError::Revert(None)));
 
     let error = result_2.unwrap_err().inner;
-    assert!(matches!(error, ExecutionError::InvalidOpcode));
+    assert!(matches!(error, ExecutionError::Web3(_)));
 }


### PR DESCRIPTION
Fixes CI

A few issues are preventing the KMS PR to build (completely unrelated to that feature), so it probably makes sense to isolate those changes:
1. Min supported rust version now seems to be 1.65 now
2. There seems to be a clippy false negative wrt unnecessary clones (can repro locally on cargo v1.70). Fix is to ignore the warning
3. Ganache is violating the [strict JSON RPC serialisation](https://github.com/paritytech/jsonrpc/blob/master/core/src/types/response.rs#L33), mixing error and success fields in its response (and on newer versions even mingling more unknown fields)
<img width="805" alt="image" src="https://github.com/cowprotocol/ethcontract-rs/assets/1200333/8baac2ca-1868-4152-9d79-c4546f14d2dd">

Fix is to use foundry anvil

This requires changes in the github actions and subtle changes in the example (different chain_id, handing invalid opcode responses slightly differently)


### Test Plan
CI passing 🤞 
