### PR TITLE
[KMS] Trim signature bytes for RLP encoding

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.67.0
+          - rust: 1.68.0
             examples: false
             continue-on-error: false
           - rust: stable

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.65.0
+          - rust: 1.67.0
             examples: false
             continue-on-error: false
           - rust: stable

--- a/ethcontract/src/log.rs
+++ b/ethcontract/src/log.rs
@@ -256,7 +256,9 @@ async fn block_number(
     }
     let block_ = web3.eth().block(BlockId::Number(block)).await?;
     let Some(block_) = block_ else {
-        return  Err(Web3Error::InvalidResponse(format!("block {block:?} does not exist")));
+        return Err(Web3Error::InvalidResponse(format!(
+            "block {block:?} does not exist"
+        )));
     };
     Ok(block_.number.map(|n| n.as_u64()))
 }

--- a/ethcontract/src/transaction/kms.rs
+++ b/ethcontract/src/transaction/kms.rs
@@ -160,8 +160,10 @@ impl Account {
             encoder.append_raw(item.as_raw(), 1);
         }
         encoder.append(&v);
-        encoder.append(&signature.r);
-        encoder.append(&signature.s);
+        // RLP encoding doesn't allow leading zeros for s & r, yet default H256 RLP encoding preserves leading 0s
+        // By converting and encoding U256, we get rid of the leading zeros.
+        encoder.append(&U256::from(signature.r.as_bytes()));
+        encoder.append(&U256::from(signature.s.as_bytes()));
 
         let raw_transaction = Bytes(match id {
             Some(id) => [&[id], encoder.as_raw()].concat(),

--- a/ethcontract/src/transport.rs
+++ b/ethcontract/src/transport.rs
@@ -64,7 +64,7 @@ where
 
     #[inline(always)]
     fn send_batch_boxed(&self, requests: Vec<(RequestId, Call)>) -> BoxedBatch {
-        self.send_batch(requests.into_iter()).boxed()
+        self.send_batch(requests).boxed()
     }
 
     #[inline(always)]


### PR DESCRIPTION
Fixes issues that sometimes invalid raw transaction bytes are generated when using AWS. E.g. 

```
0xf86b0285012a05f2008261a8948b733353ce21ebd8eb5ffd9f49d57830942e88158769ec95a3fa70008025a04f9dd75069b51d36ec47b5bf68e6c45f8b854cf17a661e734e7a7c651240eeaca00044280475c3d355c44829ac93118b4ebe044356185c1c08724c8bcfebbd4b3d
```

The issue seems to be that we use the web3 `Signature` type, which encodes s and r as H256 (really they are just points on a curve). Later in the code, we RLP encode those value to create the signed raw transaction. Ethereum requires, at least in the context of signatures, the minimal length RLP encoding for values (no leading 0s).
[H256's RLP encoding](https://rust.velas.com/src/impl_rlp/lib.rs.html#50-72) implementation does not trim leading 0s. U256's implementation however does trim leading 0s ([source](https://rust.velas.com/src/impl_rlp/lib.rs.html#21-46)).

This PR addresses the issue by converting the H256 into U256 just before RLP encoding it.

### Test Plan
Things still work:

```
cargo run --example kms
```

To ensure we can "just" trim the bytes of a leading 0 signature I used this raw tx that our backend generated (cf above), loaded it into https://toolkit.abdk.consulting/ethereum#rlp,transaction, removed the leading 0s from the last element and then successfully decoded it in https://tools.deth.net/tx-decoder
