### PR TITLE
Faciliate `StorageAccessbile` Simulations

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
-ethcontract-common = { version = "0.25.1", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.25.1", path = "../ethcontract-generate", default-features = false }
+ethcontract-common = { version = "0.25.2", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.25.2", path = "../ethcontract-generate", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ http = ["curl"]
 [dependencies]
 anyhow = "1.0"
 curl = { version = "0.4", optional = true }
-ethcontract-common = { version = "0.25.1", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.25.2", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-mock"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ Tools for mocking ethereum contracts.
 """
 
 [dependencies]
-ethcontract = { version = "0.25.1", path = "../ethcontract", default-features = false, features = ["derive"] }
+ethcontract = { version = "0.25.2", path = "../ethcontract", default-features = false, features = ["derive"] }
 hex = "0.4"
 mockall = "0.11"
 rlp = "0.5"
@@ -20,4 +20,4 @@ predicates = "3.0"
 
 [dev-dependencies]
 tokio = { version = "1.6", features = ["macros", "rt"] }
-ethcontract-derive = { version = "0.25.1", path = "../ethcontract-derive", default-features = false }
+ethcontract-derive = { version = "0.25.2", path = "../ethcontract-derive", default-features = false }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -35,8 +35,8 @@ ws-tokio = ["web3/ws-tokio"]
 aws-config = { version = "0.55", optional = true }
 aws-sdk-kms = { version = "0.28", optional = true }
 arrayvec = "0.7"
-ethcontract-common = { version = "0.25.1", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.25.1", path = "../ethcontract-derive", optional = true, default-features = false }
+ethcontract-common = { version = "0.25.2", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.25.2", path = "../ethcontract-derive", optional = true, default-features = false }
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"

--- a/ethcontract/src/contract/method.rs
+++ b/ethcontract/src/contract/method.rs
@@ -266,7 +266,7 @@ impl<T: Transport, R: Tokenize> ViewMethodBuilder<T, R> {
             self.m.function,
             CallRequest {
                 from: self.m.tx.from.map(|account| account.address()),
-                to: self.m.tx.to.unwrap_or_default(),
+                to: self.m.tx.to,
                 gas: self.m.tx.gas,
                 gas_price: resolved_gas_price.gas_price,
                 value: self.m.tx.value,

--- a/ethcontract/src/contract/method.rs
+++ b/ethcontract/src/contract/method.rs
@@ -71,6 +71,11 @@ impl<T: Transport, R: Tokenize> MethodBuilder<T, R> {
         self
     }
 
+    /// Returns a reference to the underling ABI function for this call.
+    pub fn function(&self) -> &Function {
+        &self.function
+    }
+
     /// Specify the signing method to use for the transaction, if not specified
     /// the the transaction will be locally signed with the default user.
     pub fn from(mut self, value: Account) -> Self {
@@ -175,6 +180,11 @@ impl<T: Transport, R: Tokenize> ViewMethodBuilder<T, R> {
         self
     }
 
+    /// Returns a reference to the underling ABI function for this call.
+    pub fn function(&self) -> &Function {
+        &self.m.function
+    }
+
     /// Specify the account the transaction is being sent from.
     pub fn from(mut self, value: Address) -> Self {
         self.m = self.m.from(Account::Local(value, None));
@@ -256,7 +266,7 @@ impl<T: Transport, R: Tokenize> ViewMethodBuilder<T, R> {
             self.m.function,
             CallRequest {
                 from: self.m.tx.from.map(|account| account.address()),
-                to: Some(self.m.tx.to.unwrap_or_default()),
+                to: self.m.tx.to.unwrap_or_default(),
                 gas: self.m.tx.gas,
                 gas_price: resolved_gas_price.gas_price,
                 value: self.m.tx.value,


### PR DESCRIPTION
This PR does a couple of small QoL changes in order to make using `ethcontract` with `StorageAccessible` more practical:

1. It no longer overwrites the `to` address to `0` if it is set to `None` (this allows the "constructor simulation" pattern to work)
2. It exposes a reference to the underlying ABI `function` that is being called.

Also, we bump the version in preparation for a new release.

### Test Plan

CI
