### PR TITLE
Reduce minor compilation warnings

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-common/src/bytecode.rs
+++ b/ethcontract-common/src/bytecode.rs
@@ -36,10 +36,7 @@ impl Bytecode {
         for block in CodeIter(s) {
             let block = block?;
 
-            if let Some(pos) = block
-                .bytes()
-                .position(|b| !matches!(b, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F'))
-            {
+            if let Some(pos) = block.bytes().position(|b| !b.is_ascii_hexdigit()) {
                 return Err(BytecodeError::InvalidHexDigit(
                     block.chars().nth(pos).expect("valid pos"),
                 ));

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
-ethcontract-common = { version = "0.25.2", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.25.2", path = "../ethcontract-generate", default-features = false }
+ethcontract-common = { version = "0.25.3", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.25.3", path = "../ethcontract-generate", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ http = ["curl"]
 [dependencies]
 anyhow = "1.0"
 curl = { version = "0.4", optional = true }
-ethcontract-common = { version = "0.25.2", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.25.3", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract-generate/src/generate/events.rs
+++ b/ethcontract-generate/src/generate/events.rs
@@ -500,7 +500,7 @@ fn expand_event_parse_log(cx: &Context) -> TokenStream {
                 log: self::ethcontract::RawLog,
             ) -> Result<Self, self::ethcontract::errors::ExecutionError> {
                 let standard_event = log.topics
-                    .get(0)
+                    .first()
                     .copied()
                     .map(|topic| match topic {
                         #( #standard_event_match_arms )*
@@ -793,7 +793,7 @@ mod tests {
                     log: self::ethcontract::RawLog,
                 ) -> Result<Self, self::ethcontract::errors::ExecutionError> {
                     let standard_event = log.topics
-                        .get(0)
+                        .first()
                         .copied()
                         .map(|topic| match topic {
                             #foo_signature => Ok(Event::Foo(

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-mock"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ Tools for mocking ethereum contracts.
 """
 
 [dependencies]
-ethcontract = { version = "0.25.2", path = "../ethcontract", default-features = false, features = ["derive"] }
+ethcontract = { version = "0.25.3", path = "../ethcontract", default-features = false, features = ["derive"] }
 hex = "0.4"
 mockall = "0.11"
 rlp = "0.5"
@@ -20,4 +20,4 @@ predicates = "3.0"
 
 [dev-dependencies]
 tokio = { version = "1.6", features = ["macros", "rt"] }
-ethcontract-derive = { version = "0.25.2", path = "../ethcontract-derive", default-features = false }
+ethcontract-derive = { version = "0.25.3", path = "../ethcontract-derive", default-features = false }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -35,8 +35,8 @@ ws-tokio = ["web3/ws-tokio"]
 aws-config = { version = "0.55", optional = true }
 aws-sdk-kms = { version = "0.28", optional = true }
 arrayvec = "0.7"
-ethcontract-common = { version = "0.25.2", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.25.2", path = "../ethcontract-derive", optional = true, default-features = false }
+ethcontract-common = { version = "0.25.3", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.25.3", path = "../ethcontract-derive", optional = true, default-features = false }
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"

--- a/ethcontract/src/errors/nethermind.rs
+++ b/ethcontract/src/errors/nethermind.rs
@@ -46,6 +46,7 @@ fn get_error_message(err: &JsonrpcError) -> &str {
         .unwrap_or(&err.message)
 }
 
+#[allow(unused)]
 #[cfg(test)]
 pub use tests::*;
 

--- a/ethcontract/src/test/prelude.rs
+++ b/ethcontract/src/test/prelude.rs
@@ -4,6 +4,7 @@ pub use crate::test::transport::TestTransport;
 use futures::future::FutureExt;
 pub use serde_json::json;
 use std::future::Future;
+#[allow(unused)]
 pub use web3::api::Web3;
 
 /// An extension future to wait for a future.

--- a/ethcontract/src/transaction/build.rs
+++ b/ethcontract/src/transaction/build.rs
@@ -187,7 +187,7 @@ async fn build_transaction_request_for_local_signing<T: Transport>(
             .eth()
             .accounts()
             .await?
-            .get(0)
+            .first()
             .ok_or(ExecutionError::NoLocalAccounts)?,
     };
     let gas = resolve_gas_limit(&web3, from, &options.0).await?;


### PR DESCRIPTION
Eliminates minor compilation warnings while using the generated smart contracts:
> warning: accessing first element with `log . topics.get(0)`
 --> /Users/squadgazzz/RustroverProjects/services/target/debug/build/contracts-3ef65e6ec386b1a7/out/IUniswapV3Factory.rs:1:29696
  |
1 | ...ntract :: errors :: ExecutionError > { let standard_event = log . topics . get (0) . copied () . map (| topic | match topic { self :: ethcontract :: H256 ([198 , 106 , 63 , 223...
  |                                                                ^^^^^^^^^^^^^^^^^^^^^^ help: try: `log . topics.first()`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first