### PR TITLE
Skip rehashing function signatures

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
-ethcontract-common = { version = "0.25.3", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.25.3", path = "../ethcontract-generate", default-features = false }
+ethcontract-common = { version = "0.25.4", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.25.4", path = "../ethcontract-generate", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ http = ["curl"]
 [dependencies]
 anyhow = "1.0"
 curl = { version = "0.4", optional = true }
-ethcontract-common = { version = "0.25.3", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.25.4", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-mock"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ Tools for mocking ethereum contracts.
 """
 
 [dependencies]
-ethcontract = { version = "0.25.3", path = "../ethcontract", default-features = false, features = ["derive"] }
+ethcontract = { version = "0.25.4", path = "../ethcontract", default-features = false, features = ["derive"] }
 hex = "0.4"
 mockall = "0.11"
 rlp = "0.5"
@@ -20,4 +20,4 @@ predicates = "3.0"
 
 [dev-dependencies]
 tokio = { version = "1.6", features = ["macros", "rt"] }
-ethcontract-derive = { version = "0.25.3", path = "../ethcontract-derive", default-features = false }
+ethcontract-derive = { version = "0.25.4", path = "../ethcontract-derive", default-features = false }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -35,8 +35,8 @@ ws-tokio = ["web3/ws-tokio"]
 aws-config = { version = "0.55", optional = true }
 aws-sdk-kms = { version = "0.28", optional = true }
 arrayvec = "0.7"
-ethcontract-common = { version = "0.25.3", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.25.3", path = "../ethcontract-derive", optional = true, default-features = false }
+ethcontract-common = { version = "0.25.4", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.25.4", path = "../ethcontract-derive", optional = true, default-features = false }
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"


### PR DESCRIPTION
`ethercontract-rs` is computing and storing all the function signature hashes when generating the contract bindings.
Unfortunately we used `ethabi::function::encode_inputs()` which does not memoize the hash and therefore has to recompute it every time.
This PR makes simply makes sure that we don't rehash the signature every time.

### Test Plan
Unit tests still work and I was able to continue running the backend services using this patched version