### PR TITLE
Replace `net_version` with `eth_chainId`

### DIFF
--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
-ethcontract-common = { version = "0.25.4", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.25.4", path = "../ethcontract-generate", default-features = false }
+ethcontract-common = { version = "0.25.5", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.25.5", path = "../ethcontract-generate", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ http = ["curl"]
 [dependencies]
 anyhow = "1.0"
 curl = { version = "0.4", optional = true }
-ethcontract-common = { version = "0.25.4", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.25.5", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract-generate/src/generate/events.rs
+++ b/ethcontract-generate/src/generate/events.rs
@@ -560,7 +560,6 @@ fn expand_invalid_data() -> TokenStream {
 mod tests {
     use super::*;
     use crate::ContractBuilder;
-    use ethcontract_common::abi::{EventParam, ParamType};
     use ethcontract_common::Contract;
 
     #[test]

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-mock"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ Tools for mocking ethereum contracts.
 """
 
 [dependencies]
-ethcontract = { version = "0.25.4", path = "../ethcontract", default-features = false, features = ["derive"] }
+ethcontract = { version = "0.25.5", path = "../ethcontract", default-features = false, features = ["derive"] }
 hex = "0.4"
 mockall = "0.11"
 rlp = "0.5"
@@ -20,4 +20,4 @@ predicates = "3.0"
 
 [dev-dependencies]
 tokio = { version = "1.6", features = ["macros", "rt"] }
-ethcontract-derive = { version = "0.25.4", path = "../ethcontract-derive", default-features = false }
+ethcontract-derive = { version = "0.25.5", path = "../ethcontract-derive", default-features = false }

--- a/ethcontract-mock/src/details/mod.rs
+++ b/ethcontract-mock/src/details/mod.rs
@@ -1,7 +1,6 @@
 //! Implementation details of mock node.
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::future::ready;
 use std::sync::{Arc, Mutex};
 

--- a/ethcontract-mock/src/details/mod.rs
+++ b/ethcontract-mock/src/details/mod.rs
@@ -449,10 +449,6 @@ impl MockTransport {
                 let name = "eth_getTransactionReceipt";
                 self.eth_get_transaction_receipt(Parser::new(name, params))
             }
-            "net_version" => {
-                let name = "net_version";
-                self.net_version(Parser::new(name, params))
-            }
             unsupported => panic!("mock node does not support rpc method {:?}", unsupported),
         };
 
@@ -677,13 +673,6 @@ impl MockTransport {
         Self::ok(state.receipts.get(&transaction).unwrap_or_else(|| {
             panic!("there is no transaction with hash {:#x}", transaction);
         }))
-    }
-
-    fn net_version(&self, args: Parser) -> Result<Value, Error> {
-        args.done();
-
-        let state = self.state.lock().unwrap();
-        Self::ok(state.chain_id.to_string())
     }
 
     fn ok<T: Serialize>(t: T) -> Result<Value, Error> {

--- a/ethcontract-mock/src/test/eth_block_number.rs
+++ b/ethcontract-mock/src/test/eth_block_number.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::Mock;
 
 #[tokio::test]
 async fn block_number_initially_zero() -> Result {

--- a/ethcontract-mock/src/test/eth_chain_id.rs
+++ b/ethcontract-mock/src/test/eth_chain_id.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::Mock;
 
 #[tokio::test]
 async fn chain_id() -> Result {

--- a/ethcontract-mock/src/test/eth_gas_price.rs
+++ b/ethcontract-mock/src/test/eth_gas_price.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::Mock;
 
 #[tokio::test]
 async fn gas_price() -> Result {

--- a/ethcontract-mock/src/test/eth_transaction_count.rs
+++ b/ethcontract-mock/src/test/eth_transaction_count.rs
@@ -1,6 +1,4 @@
 use super::*;
-use crate::Mock;
-use ethcontract::BlockNumber;
 
 #[tokio::test]
 async fn transaction_count_initially_zero() -> Result {

--- a/ethcontract-mock/src/test/net_version.rs
+++ b/ethcontract-mock/src/test/net_version.rs
@@ -9,21 +9,3 @@ async fn chain_id() -> Result {
 
     Ok(())
 }
-
-#[tokio::test]
-async fn net_version() -> Result {
-    let web3 = Mock::new(1234).web3();
-
-    assert_eq!(web3.net().version().await?, "1234");
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn net_version_main() -> Result {
-    let web3 = Mock::new(1).web3(); // simulate mainnet
-
-    assert_eq!(web3.net().version().await?, "1");
-
-    Ok(())
-}

--- a/ethcontract-mock/src/test/net_version.rs
+++ b/ethcontract-mock/src/test/net_version.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::Mock;
 
 #[tokio::test]
 async fn chain_id() -> Result {

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -35,8 +35,8 @@ ws-tokio = ["web3/ws-tokio"]
 aws-config = { version = "0.55", optional = true }
 aws-sdk-kms = { version = "0.28", optional = true }
 arrayvec = "0.7"
-ethcontract-common = { version = "0.25.4", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.25.4", path = "../ethcontract-derive", optional = true, default-features = false }
+ethcontract-common = { version = "0.25.5", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.25.5", path = "../ethcontract-derive", optional = true, default-features = false }
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -445,7 +445,7 @@ mod tests {
 
         assert!(
             match &err {
-                DeployError::NotFound(id) => id == network_id.to_string(),
+                DeployError::NotFound(id) => id == &network_id.to_string(),
                 _ => false,
             },
             "expected network {} not found error but got '{:?}'",

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -389,8 +389,6 @@ mod tests {
     use super::*;
     use crate::test::prelude::*;
     use ethcontract_common::contract::Network;
-    use ethcontract_common::Contract;
-    use web3::types::H256;
 
     #[test]
     fn deployed() {

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -397,12 +397,11 @@ mod tests {
         let mut transport = TestTransport::new();
         let web3 = Web3::new(transport.clone());
 
-        let network_id = 42;
         let address = addr!("0x0102030405060708091011121314151617181920");
         let contract = {
             let mut contract = Contract::empty();
             contract.networks.insert(
-                network_id.to_string(),
+                "42".to_string(),
                 Network {
                     address,
                     deployment_information: Some(H256::repeat_byte(0x42).into()),
@@ -411,7 +410,7 @@ mod tests {
             contract
         };
 
-        transport.add_response(json!(network_id.to_string())); // get network ID response
+        transport.add_response(json!("0x2a")); // eth_chainId response
         let instance = Instance::deployed(web3, contract)
             .immediate()
             .expect("successful deployment");
@@ -433,9 +432,7 @@ mod tests {
         let mut transport = TestTransport::new();
         let web3 = Web3::new(transport.clone());
 
-        let network_id = 42;
-
-        transport.add_response(json!(network_id.to_string())); // get network ID response
+        transport.add_response(json!("0x2a")); // eth_chainId response
         let err = Instance::deployed(web3, Contract::empty())
             .immediate()
             .expect_err("unexpected success getting deployed contract");
@@ -445,11 +442,10 @@ mod tests {
 
         assert!(
             match &err {
-                DeployError::NotFound(id) => id == &network_id.to_string(),
+                DeployError::NotFound(id) => id == "42",
                 _ => false,
             },
-            "expected network {} not found error but got '{:?}'",
-            network_id,
+            "expected network 42 not found error but got '{:?}'",
             err
         );
     }

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -397,7 +397,7 @@ mod tests {
         let mut transport = TestTransport::new();
         let web3 = Web3::new(transport.clone());
 
-        let network_id = "42";
+        let network_id = 42;
         let address = addr!("0x0102030405060708091011121314151617181920");
         let contract = {
             let mut contract = Contract::empty();
@@ -411,7 +411,7 @@ mod tests {
             contract
         };
 
-        transport.add_response(json!(network_id)); // get network ID response
+        transport.add_response(network_id); // get network ID response
         let instance = Instance::deployed(web3, contract)
             .immediate()
             .expect("successful deployment");
@@ -433,7 +433,7 @@ mod tests {
         let mut transport = TestTransport::new();
         let web3 = Web3::new(transport.clone());
 
-        let network_id = "42";
+        let network_id = 42;
 
         transport.add_response(json!(network_id)); // get network ID response
         let err = Instance::deployed(web3, Contract::empty())
@@ -445,7 +445,7 @@ mod tests {
 
         assert!(
             match &err {
-                DeployError::NotFound(id) => id == network_id,
+                DeployError::NotFound(id) => id == network_id.to_string(),
                 _ => false,
             },
             "expected network {} not found error but got '{:?}'",

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -411,7 +411,7 @@ mod tests {
             contract
         };
 
-        transport.add_response(network_id); // get network ID response
+        transport.add_response(json!(network_id)); // get network ID response
         let instance = Instance::deployed(web3, contract)
             .immediate()
             .expect("successful deployment");

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -120,10 +120,10 @@ impl<T: Transport> Instance<T> {
     /// Note that this does not verify that a contract with a matching `Abi` is
     /// actually deployed at the given address.
     pub async fn deployed(web3: Web3<T>, contract: Contract) -> Result<Self, DeployError> {
-        let network_id = web3.eth().chain_id().await?;
+        let network_id = web3.eth().chain_id().await?.to_string();
         let network = contract
             .networks
-            .get(&format!("{network_id}"))
+            .get(&network_id)
             .ok_or(DeployError::NotFound(network_id))?;
 
         Ok(Instance::with_deployment_info(

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -120,10 +120,10 @@ impl<T: Transport> Instance<T> {
     /// Note that this does not verify that a contract with a matching `Abi` is
     /// actually deployed at the given address.
     pub async fn deployed(web3: Web3<T>, contract: Contract) -> Result<Self, DeployError> {
-        let network_id = web3.net().version().await?;
+        let network_id = web3.eth().chain_id().await?;
         let network = contract
             .networks
-            .get(&network_id)
+            .get(&format!("{network_id}"))
             .ok_or(DeployError::NotFound(network_id))?;
 
         Ok(Instance::with_deployment_info(
@@ -416,7 +416,7 @@ mod tests {
             .immediate()
             .expect("successful deployment");
 
-        transport.assert_request("net_version", &[]);
+        transport.assert_request("eth_chainId", &[]);
         transport.assert_no_more_requests();
 
         assert_eq!(instance.address(), address);
@@ -440,7 +440,7 @@ mod tests {
             .immediate()
             .expect_err("unexpected success getting deployed contract");
 
-        transport.assert_request("net_version", &[]);
+        transport.assert_request("eth_chainId", &[]);
         transport.assert_no_more_requests();
 
         assert!(

--- a/ethcontract/src/contract.rs
+++ b/ethcontract/src/contract.rs
@@ -411,7 +411,7 @@ mod tests {
             contract
         };
 
-        transport.add_response(json!(network_id)); // get network ID response
+        transport.add_response(json!(network_id.to_string())); // get network ID response
         let instance = Instance::deployed(web3, contract)
             .immediate()
             .expect("successful deployment");
@@ -435,7 +435,7 @@ mod tests {
 
         let network_id = 42;
 
-        transport.add_response(json!(network_id)); // get network ID response
+        transport.add_response(json!(network_id.to_string())); // get network ID response
         let err = Instance::deployed(web3, Contract::empty())
             .immediate()
             .expect_err("unexpected success getting deployed contract");

--- a/ethcontract/src/contract/deploy.rs
+++ b/ethcontract/src/contract/deploy.rs
@@ -168,7 +168,7 @@ mod tests {
     use super::*;
     use crate::contract::{Instance, Linker};
     use crate::test::prelude::*;
-    use ethcontract_common::{Bytecode, Contract};
+    use ethcontract_common::Contract;
 
     type InstanceDeployBuilder<T> = DeployBuilder<T, Instance<T>>;
 

--- a/ethcontract/src/contract/event.rs
+++ b/ethcontract/src/contract/event.rs
@@ -348,7 +348,7 @@ mod tests {
     use ethcontract_common::abi::{EventParam, ParamType};
     use futures::stream::StreamExt;
     use serde_json::Value;
-    use web3::types::{Address, H2048, H256, U256, U64};
+    use web3::types::{H2048, U256, U64};
 
     fn test_abi_event() -> (AbiEvent, Value) {
         let event = AbiEvent {

--- a/ethcontract/src/int.rs
+++ b/ethcontract/src/int.rs
@@ -3,7 +3,6 @@
 use crate::errors::{ParseI256Error, TryFromBigIntError};
 use serde::{Deserialize, Serialize};
 use std::cmp;
-use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::iter;
 use std::ops;

--- a/ethcontract/src/tokens.rs
+++ b/ethcontract/src/tokens.rs
@@ -16,7 +16,6 @@ use crate::I256;
 use arrayvec::ArrayVec;
 use ethcontract_common::{abi::Token, TransactionHash};
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 use web3::types::{Address, U256};
 
 /// A tokenization related error.

--- a/ethcontract/src/transaction.rs
+++ b/ethcontract/src/transaction.rs
@@ -227,7 +227,6 @@ impl<T: Transport> TransactionBuilder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::errors::ExecutionError;
     use crate::test::prelude::*;
     use hex_literal::hex;
     use web3::types::{AccessListItem, H2048, H256};

--- a/examples/examples/deployments.rs
+++ b/examples/examples/deployments.rs
@@ -13,8 +13,8 @@ async fn main() {
     let web3 = Web3::new(http);
 
     let network_id = web3
-        .net()
-        .version()
+        .eth()
+        .chain_id()
         .await
         .expect("failed to get network ID");
     let instance = RustCoin::deployed(&web3)

--- a/examples/examples/kms.rs
+++ b/examples/examples/kms.rs
@@ -1,7 +1,7 @@
 use ethcontract::{
     aws_config,
     prelude::*,
-    transaction::{kms, Account, TransactionBuilder},
+    transaction::{kms, TransactionBuilder},
 };
 use std::env;
 

--- a/examples/examples/revert.rs
+++ b/examples/examples/revert.rs
@@ -29,7 +29,7 @@ async fn main() {
     let error = result_0.unwrap_err().inner;
     assert!(matches!(
         error,
-        ExecutionError::Revert(Some(reason)) if reason == "reason"
+        ExecutionError::Revert(Some(reason)) if reason == "revert: reason"
     ));
 
     let error = result_1.unwrap_err().inner;


### PR DESCRIPTION
Fixes #966

* replaces `net_version` calls with `eth_chainId` because that is supported by all nodes by default whereas the `net` functions might not be.
* bumps the version so we can immediately start using this improvement in the services repo
* gets rid of unnecessary imports to avoid clippy warnings on nightly

### Test Plan
Adjusted existing tests