### PR TITLE
Do not panic in the `kms::sign()` function

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.70.0
+          - rust: 1.74.0
             examples: false
             continue-on-error: false
           - rust: stable

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,6 +36,9 @@ jobs:
           default: true
       - uses: Swatinem/rust-cache@v1
       - uses: foundry-rs/foundry-toolchain@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - run: cargo fmt -- --check
       - run: cd examples/truffle && yarn --frozen-lockfile && yarn build
       # Can't use --all-features here because web3 has mutually exclusive features.

--- a/ethcontract-common/Cargo.toml
+++ b/ethcontract-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-common"
-version = "0.25.7"
+version = "0.25.8"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ethcontract-common/src/artifact.rs
+++ b/ethcontract-common/src/artifact.rs
@@ -149,7 +149,7 @@ pub struct InsertResult<'a> {
 /// but doesn't allow changing its name.
 pub struct ContractMut<'a>(&'a mut Contract);
 
-impl<'a> ContractMut<'a> {
+impl ContractMut<'_> {
     /// Returns mutable reference to contract's abi.
     pub fn abi_mut(&mut self) -> &mut Abi {
         &mut Arc::make_mut(&mut self.0.interface).abi

--- a/ethcontract-common/src/bytecode.rs
+++ b/ethcontract-common/src/bytecode.rs
@@ -163,7 +163,7 @@ impl<'de> Deserialize<'de> for Bytecode {
 /// A serde visitor for deserializing bytecode.
 struct BytecodeVisitor;
 
-impl<'de> Visitor<'de> for BytecodeVisitor {
+impl Visitor<'_> for BytecodeVisitor {
     type Value = Bytecode;
 
     fn expecting(&self, f: &mut Formatter) -> FmtResult {

--- a/ethcontract-derive/Cargo.toml
+++ b/ethcontract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-derive"
-version = "0.25.7"
+version = "0.25.8"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
-ethcontract-common = { version = "0.25.7", path = "../ethcontract-common" }
-ethcontract-generate = { version = "0.25.7", path = "../ethcontract-generate", default-features = false }
+ethcontract-common = { version = "0.25.8", path = "../ethcontract-common" }
+ethcontract-generate = { version = "0.25.8", path = "../ethcontract-generate", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/ethcontract-generate/Cargo.toml
+++ b/ethcontract-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-generate"
-version = "0.25.7"
+version = "0.25.8"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ http = ["curl"]
 [dependencies]
 anyhow = "1.0"
 curl = { version = "0.4", optional = true }
-ethcontract-common = { version = "0.25.7", path = "../ethcontract-common" }
+ethcontract-common = { version = "0.25.8", path = "../ethcontract-common" }
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethcontract-mock/Cargo.toml
+++ b/ethcontract-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract-mock"
-version = "0.25.7"
+version = "0.25.8"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ Tools for mocking ethereum contracts.
 """
 
 [dependencies]
-ethcontract = { version = "0.25.7", path = "../ethcontract", default-features = false, features = ["derive"] }
+ethcontract = { version = "0.25.8", path = "../ethcontract", default-features = false, features = ["derive"] }
 hex = "0.4"
 mockall = "0.11"
 rlp = "0.5"
@@ -20,4 +20,4 @@ predicates = "3.0"
 
 [dev-dependencies]
 tokio = { version = "1.6", features = ["macros", "rt"] }
-ethcontract-derive = { version = "0.25.7", path = "../ethcontract-derive", default-features = false }
+ethcontract-derive = { version = "0.25.8", path = "../ethcontract-derive", default-features = false }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethcontract"
-version = "0.25.7"
+version = "0.25.8"
 authors = ["Gnosis developers <developers@gnosis.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -35,8 +35,8 @@ ws-tokio = ["web3/ws-tokio"]
 aws-config = { version = "0.55", optional = true }
 aws-sdk-kms = { version = "0.28", optional = true }
 arrayvec = "0.7"
-ethcontract-common = { version = "0.25.7", path = "../ethcontract-common" }
-ethcontract-derive = { version = "0.25.7", path = "../ethcontract-derive", optional = true, default-features = false }
+ethcontract-common = { version = "0.25.8", path = "../ethcontract-common" }
+ethcontract-derive = { version = "0.25.8", path = "../ethcontract-derive", optional = true, default-features = false }
 futures = "0.3"
 futures-timer = "3.0"
 hex = "0.4"

--- a/ethcontract/src/log.rs
+++ b/ethcontract/src/log.rs
@@ -15,6 +15,7 @@ use web3::Transport;
 /// The default poll interval to use for polling logs from the block chain.
 #[cfg(not(test))]
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(5);
+/// The default poll interval to be used in tests.
 #[cfg(test)]
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(0);
 

--- a/ethcontract/src/transaction/kms.rs
+++ b/ethcontract/src/transaction/kms.rs
@@ -5,7 +5,6 @@
 //!
 //! It's quite hacky, however the hackiness does not leak outside this module.
 
-use aws_sdk_kms::operation::sign::SignOutput;
 use aws_sdk_kms::{
     primitives::Blob,
     types::{KeySpec, KeyUsageType, MessageType, SigningAlgorithmSpec},

--- a/ethcontract/src/transaction/kms.rs
+++ b/ethcontract/src/transaction/kms.rs
@@ -5,6 +5,7 @@
 //!
 //! It's quite hacky, however the hackiness does not leak outside this module.
 
+use aws_sdk_kms::operation::sign::SignOutput;
 use aws_sdk_kms::{
     primitives::Blob,
     types::{KeySpec, KeyUsageType, MessageType, SigningAlgorithmSpec},
@@ -86,8 +87,7 @@ impl Account {
             .signing_algorithm(SigningAlgorithmSpec::EcdsaSha256)
             .send()
             .await
-            .map_err(aws_sdk_kms::Error::from)
-            .unwrap();
+            .map_err(aws_sdk_kms::Error::from)?;
         let signature = secp256k1::ecdsa::Signature::from_der(
             output.signature().ok_or(Error::InvalidSignature)?.as_ref(),
         )


### PR DESCRIPTION
Removes unnecessary `unwrap()` call inside the `kms::sign()` function, which leads to unexpected behavior from the client side.

Also, includes workarounds in order to build the project with outdated dependencies.