### PR TITLE
chore(ci): upgrade setup-node to v4

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,7 +36,7 @@ jobs:
           default: true
       - uses: Swatinem/rust-cache@v1
       - uses: foundry-rs/foundry-toolchain@v1
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - run: cargo fmt -- --check


### PR DESCRIPTION
Maintenance update to setup-node@v4 to align with the current best practices; nothing else modified. Refer to [v4.0.0 release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0) for details.