### PR TITLE
KMS account getters

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.74.0
+          - rust: 1.82.0
             examples: false
             continue-on-error: false
           - rust: stable

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.82.0
+          - rust: 1.89.0
             examples: false
             continue-on-error: false
           - rust: stable

--- a/ethcontract-common/src/artifact.rs
+++ b/ethcontract-common/src/artifact.rs
@@ -94,7 +94,7 @@ impl Artifact {
     ///
     /// If contract with this name already exists, replaces it
     /// and returns the old contract.
-    pub fn insert(&mut self, contract: Contract) -> InsertResult<"_"> {
+    pub fn insert(&mut self, contract: Contract) -> InsertResult<'_> {
         match self.contracts.entry(contract.name.clone()) {
             Entry::Occupied(mut o) => {
                 let old_contract = o.insert(contract);

--- a/ethcontract-common/src/artifact.rs
+++ b/ethcontract-common/src/artifact.rs
@@ -86,7 +86,7 @@ impl Artifact {
     ///
     /// The returned handle does not allow renaming contract. For that,
     /// you'll need to remove it and add again.
-    pub fn get_mut(&mut self, name: &str) -> Option<ContractMut> {
+    pub fn get_mut(&mut self, name: &str) -> Option<ContractMut<'_>> {
         self.contracts.get_mut(name).map(ContractMut)
     }
 
@@ -94,7 +94,7 @@ impl Artifact {
     ///
     /// If contract with this name already exists, replaces it
     /// and returns the old contract.
-    pub fn insert(&mut self, contract: Contract) -> InsertResult {
+    pub fn insert(&mut self, contract: Contract) -> InsertResult<"_"> {
         match self.contracts.entry(contract.name.clone()) {
             Entry::Occupied(mut o) => {
                 let old_contract = o.insert(contract);

--- a/ethcontract-common/src/artifact/hardhat.rs
+++ b/ethcontract-common/src/artifact/hardhat.rs
@@ -281,8 +281,7 @@ impl HardHatLoader {
             let chain_name = chain_path
                 .file_name()
                 .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
+                    std::io::Error::other(
                         format!("unable to get directory name for path {:?}", chain_path),
                     )
                 })?
@@ -303,8 +302,7 @@ impl HardHatLoader {
                 let mut contract_name = contract_path
                     .file_name()
                     .ok_or_else(|| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::Other,
+                        std::io::Error::other(
                             format!("unable to get file name for path {:?}", contract_path),
                         )
                     })?

--- a/ethcontract-common/src/artifact/hardhat.rs
+++ b/ethcontract-common/src/artifact/hardhat.rs
@@ -281,9 +281,10 @@ impl HardHatLoader {
             let chain_name = chain_path
                 .file_name()
                 .ok_or_else(|| {
-                    std::io::Error::other(
-                        format!("unable to get directory name for path {:?}", chain_path),
-                    )
+                    std::io::Error::other(format!(
+                        "unable to get directory name for path {:?}",
+                        chain_path
+                    ))
                 })?
                 .to_string_lossy();
 
@@ -302,9 +303,10 @@ impl HardHatLoader {
                 let mut contract_name = contract_path
                     .file_name()
                     .ok_or_else(|| {
-                        std::io::Error::other(
-                            format!("unable to get file name for path {:?}", contract_path),
-                        )
+                        std::io::Error::other(format!(
+                            "unable to get file name for path {:?}",
+                            contract_path
+                        ))
                     })?
                     .to_string_lossy()
                     .into_owned();

--- a/ethcontract-common/src/bytecode.rs
+++ b/ethcontract-common/src/bytecode.rs
@@ -25,7 +25,7 @@ impl Bytecode {
         }
 
         // Verify that the length is even
-        if s.len() % 2 != 0 {
+        if !s.len().is_multiple_of(2) {
             return Err(BytecodeError::InvalidLength);
         }
 

--- a/ethcontract/src/errors/revert.rs
+++ b/ethcontract/src/errors/revert.rs
@@ -15,7 +15,7 @@ lazy_static! {
 /// These reasons are prefixed by a 4-byte error followed by an ABI encoded
 /// string.
 pub fn decode_reason(bytes: &[u8]) -> Option<String> {
-    if (!(bytes.len() + 28).is_multiple_of(32) || bytes[0..4] != ERROR_SELECTOR[..] {
+    if !(bytes.len() + 28).is_multiple_of(32) || bytes[0..4] != ERROR_SELECTOR[..] {
         // check to make sure that the length is of the form `4 + (n * 32)`
         // bytes and it starts with `keccak256("Error(string)")` which means
         // it is an encoded revert reason from Geth nodes.

--- a/ethcontract/src/errors/revert.rs
+++ b/ethcontract/src/errors/revert.rs
@@ -15,7 +15,7 @@ lazy_static! {
 /// These reasons are prefixed by a 4-byte error followed by an ABI encoded
 /// string.
 pub fn decode_reason(bytes: &[u8]) -> Option<String> {
-    if (bytes.len() + 28) % 32 != 0 || bytes[0..4] != ERROR_SELECTOR[..] {
+    if (!(bytes.len() + 28).is_multiple_of(32) || bytes[0..4] != ERROR_SELECTOR[..] {
         // check to make sure that the length is of the form `4 + (n * 32)`
         // bytes and it starts with `keccak256("Error(string)")` which means
         // it is an encoded revert reason from Geth nodes.

--- a/ethcontract/src/int.rs
+++ b/ethcontract/src/int.rs
@@ -876,7 +876,7 @@ impl I256 {
     /// of exponentiation can be computed even if the actual result is too large
     /// to fit in 256-bit signed integer.
     fn pow_sign(self, exp: u32) -> Sign {
-        let is_exp_odd = exp % 2 != 0;
+        let is_exp_odd = !exp.is_multiple_of(2);
         if is_exp_odd && self.is_negative() {
             Sign::Negative
         } else {

--- a/ethcontract/src/transaction/kms.rs
+++ b/ethcontract/src/transaction/kms.rs
@@ -75,6 +75,16 @@ impl Account {
         self.address
     }
 
+    /// Returns the underlying KMS client.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    /// Returns the KMS Key ID.
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
     /// Signs a message.
     pub async fn sign(&self, message: [u8; 32]) -> Result<Signature, Error> {
         let output = self

--- a/examples/examples/revert.rs
+++ b/examples/examples/revert.rs
@@ -29,7 +29,7 @@ async fn main() {
     let error = result_0.unwrap_err().inner;
     assert!(matches!(
         error,
-        ExecutionError::Revert(Some(reason)) if reason == "revert: reason"
+        ExecutionError::Revert(Some(reason)) if reason == "reason"
     ));
 
     let error = result_1.unwrap_err().inner;


### PR DESCRIPTION
This PR adds getters for KMS account, which is currently required for cowprotocol/services to migrate to alloy, where AwsSigner requires these fields: https://github.com/alloy-rs/alloy/blob/77d725b26321e1e3674b171c0788a13926870dd7/crates/signer-aws/src/signer.rs#L140-L147

Also contains changes in order to pass compilation on the latest rust versions.