### PR TITLE
Update aws versions

### DIFF
--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -32,8 +32,8 @@ ws-tls-tokio = ["web3/ws-tls-tokio"]
 ws-tokio = ["web3/ws-tokio"]
 
 [dependencies]
-aws-config = { version = "0.55", optional = true }
-aws-sdk-kms = { version = "0.28", optional = true }
+aws-config = { version = "1.8", optional = true }
+aws-sdk-kms = { version = "1.85", optional = true }
 arrayvec = "0.7"
 ethcontract-common = { version = "0.25.9", path = "../ethcontract-common" }
 ethcontract-derive = { version = "0.25.9", path = "../ethcontract-derive", optional = true, default-features = false }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -32,8 +32,8 @@ ws-tls-tokio = ["web3/ws-tls-tokio"]
 ws-tokio = ["web3/ws-tokio"]
 
 [dependencies]
-aws-config = { version = "1.8", optional = true }
-aws-sdk-kms = { version = "1.85", optional = true }
+aws-config = { version = "1.5.1", optional = true }
+aws-sdk-kms = { version = "1.5.1", optional = true }
 arrayvec = "0.7"
 ethcontract-common = { version = "0.25.9", path = "../ethcontract-common" }
 ethcontract-derive = { version = "0.25.9", path = "../ethcontract-derive", optional = true, default-features = false }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -32,8 +32,8 @@ ws-tls-tokio = ["web3/ws-tls-tokio"]
 ws-tokio = ["web3/ws-tokio"]
 
 [dependencies]
-aws-config = { version = "1.5.1", optional = true }
-aws-sdk-kms = { version = "1.5.1", optional = true }
+aws-config = { version = "1.8.6", optional = true }
+aws-sdk-kms = { version = "1.86", optional = true }
 arrayvec = "0.7"
 ethcontract-common = { version = "0.25.9", path = "../ethcontract-common" }
 ethcontract-derive = { version = "0.25.9", path = "../ethcontract-derive", optional = true, default-features = false }

--- a/examples/examples/kms.rs
+++ b/examples/examples/kms.rs
@@ -8,7 +8,7 @@ use std::env;
 #[tokio::main]
 async fn main() {
     // Run `aws configure export-credentials --profile cow-staging --format env` to get required env variable locally
-    let config = aws_config::load_from_env().await;
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
     let account = kms::Account::new(
         (&config).into(),
         &env::var("KMS_KEY_ID").expect("KMS_KEY_ID not set"),


### PR DESCRIPTION
Updates aws dependencies to the latest versions. Another requirement for the cowprotocol/services transition to allloy is that it uses AWS v1 which is incompatible with the v0.x used in this repository.