### PR TITLE
Downgrade aws libs

### DIFF
--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -33,7 +33,7 @@ ws-tokio = ["web3/ws-tokio"]
 
 [dependencies]
 aws-config = { version = "1.5.1", optional = true }
-aws-sdk-kms = { version = "1.86", optional = true }
+aws-sdk-kms = { version = "1.5.1", optional = true }
 arrayvec = "0.7"
 ethcontract-common = { version = "0.25.9", path = "../ethcontract-common" }
 ethcontract-derive = { version = "0.25.9", path = "../ethcontract-derive", optional = true, default-features = false }

--- a/ethcontract/Cargo.toml
+++ b/ethcontract/Cargo.toml
@@ -32,7 +32,7 @@ ws-tls-tokio = ["web3/ws-tls-tokio"]
 ws-tokio = ["web3/ws-tokio"]
 
 [dependencies]
-aws-config = { version = "1.8.6", optional = true }
+aws-config = { version = "1.5.1", optional = true }
 aws-sdk-kms = { version = "1.86", optional = true }
 arrayvec = "0.7"
 ethcontract-common = { version = "0.25.9", path = "../ethcontract-common" }


### PR DESCRIPTION
It is not possible to use latest versions without updating cargo lockfile in the cowprotocol/services repo, which caused memory consumption issues, so this PR downgrades aws libs to versions that don't require that anymore.