### PR TITLE
Call with state overrides

### DIFF
--- a/ethcontract/src/lib.rs
+++ b/ethcontract/src/lib.rs
@@ -99,6 +99,7 @@ pub mod errors;
 mod int;
 pub mod log;
 pub mod secret;
+pub mod state_overrides;
 pub mod tokens;
 pub mod transaction;
 pub mod transport;

--- a/ethcontract/src/state_overrides.rs
+++ b/ethcontract/src/state_overrides.rs
@@ -1,0 +1,37 @@
+//! Contains data structures needed to specify
+//! state overrides for `eth_call`s.
+
+use primitive_types::{H160, H256, U256};
+use serde::Serialize;
+use std::collections::HashMap;
+use web3::types::{U64, Bytes};
+
+/// State overrides.
+pub type StateOverrides = HashMap<H160, StateOverride>;
+
+/// State override object.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StateOverride {
+    /// Fake balance to set for the account before executing the call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub balance: Option<U256>,
+
+    /// Fake nonce to set for the account before executing the call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<U64>,
+
+    /// Fake EVM bytecode to inject into the account before executing the call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<Bytes>,
+
+    /// Fake key-value mapping to override **all** slots in the account storage
+    /// before executing the call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<HashMap<H256, H256>>,
+
+    /// Fake key-value mapping to override **individual** slots in the account
+    /// storage before executing the call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_diff: Option<HashMap<H256, H256>>,
+}

--- a/ethcontract/src/state_overrides.rs
+++ b/ethcontract/src/state_overrides.rs
@@ -4,7 +4,7 @@
 use primitive_types::{H160, H256, U256};
 use serde::Serialize;
 use std::collections::HashMap;
-use web3::types::{U64, Bytes};
+use web3::types::{Bytes, U64};
 
 /// State overrides.
 pub type StateOverrides = HashMap<H160, StateOverride>;


### PR DESCRIPTION
Using `eth_call` together with state overrides is pretty useful and widely supported thing. Currently we need to use very ugly workaround in https://github.com/cowprotocol/services to use state overrides with `ethcontract-rs`.
In order to make everyone's lives easier it makes the most sense to make `call_with_state_overrides` a first class citizen in `ethcontract-rs`.

- I added the `StateOverride` struct which defines the format of things that can be overriden
- I added `call_with_state_overrides` on `MethodCallBuilder` and `ViewCallBuilder`
    - unfortunately does the `web3` crate not have any nice helper functions for using state overrides so I implemented the call with the underlying logic that the `web3` crate would have called

### Test Plan
I tested this by pointing the ethcontract dependency in the cowprotocol repo to a local checkout with this patch and did a manual test to make sure things work. Given that we are about to completely abandon this crate I think it's fine to check in a test specific for this.